### PR TITLE
Use the full form of the rnids as input to the lattice generator.

### DIFF
--- a/src/BayesBaseCT_SortMerge.java
+++ b/src/BayesBaseCT_SortMerge.java
@@ -1355,7 +1355,12 @@ public class BayesBaseCT_SortMerge {
             Statement st3 = con_CT.createStatement();
 
             //  create ColumnString
-            ResultSet rs2 = st2.executeQuery("select distinct Entries from MetaQueries where Lattice_Point = '" + short_rnid + "' and TableType = 'Join';");
+            ResultSet rs2 = st2.executeQuery(
+                "SELECT DISTINCT Entries " +
+                "FROM MetaQueries " +
+                "WHERE Lattice_Point = '" + orig_rnid + "' " +
+                "AND TableType = 'Join';"
+            );
 
             String ColumnString = makeCommaSepQuery(rs2, "Entries", " , ");
             ColumnString = orig_rnid + " varchar(5) ," + ColumnString;

--- a/src/BayesBaseCT_SortMerge.java
+++ b/src/BayesBaseCT_SortMerge.java
@@ -895,12 +895,20 @@ public class BayesBaseCT_SortMerge {
     public static void BuildCT_Rnodes_counts(int len) throws SQLException, IOException {
 
         Statement st = con_BN.createStatement();
-        ResultSet rs = st.executeQuery("select name as RChain from lattice_set where lattice_set.length = " + len + ";");
+        ResultSet rs = st.executeQuery(
+            "SELECT short_rnid AS short_RChain, orig_rnid AS RChain " +
+            "FROM lattice_set " +
+            "JOIN lattice_mapping " +
+            "ON lattice_set.name = lattice_mapping.orig_rnid " +
+            "WHERE lattice_set.length = " + len + ";"
+        );
         while(rs.next()){
 
-            //  get rnid for further use
+            // Get the short and full form rnids for further use.
             String rchain = rs.getString("RChain");
             System.out.println("\n RChain : " + rchain);
+            String shortRchain = rs.getString("short_RChain");
+            System.out.println(" Short RChain : " + shortRchain);
 
             //  create new statement
             Statement st2 = con_BN.createStatement();
@@ -936,24 +944,29 @@ public class BayesBaseCT_SortMerge {
                 //System.out.println("Query String : " + queryString );
             }
 
-            String createString = "create table `"+rchain.replace("`", "") +"_counts`"+" as "+queryString;
+            String createString = "CREATE TABLE `" + shortRchain.replace("`", "") + "_counts`" + " AS " + queryString;
             System.out.println("create String : " + createString );
             st3.execute(createString);
 
             //adding  covering index May 21
             //create index string
-            ResultSet rs5 = st2.executeQuery("select column_name as Entries from information_schema.columns where table_schema = '"+databaseName_CT+"' and table_name = '"+rchain.replace("`", "") +"_counts';");
+            ResultSet rs5 = st2.executeQuery(
+                "SELECT column_name AS Entries " +
+                "FROM information_schema.columns " +
+                "WHERE table_schema = '" + databaseName_CT + "' " +
+                "AND table_name = '" + shortRchain.replace("`", "") + "_counts';"
+            );
             String IndexString = makeIndexQuery(rs5, "Entries", " , ");
             //System.out.println("Index String : " + IndexString);
             //System.out.println("alter table `"+rchain.replace("`", "") +"_counts`"+" add index `"+rchain.replace("`", "") +"_Index`   ( "+IndexString+" );");
-            st3.execute("alter table `"+rchain.replace("`", "") +"_counts`"+" add index `"+rchain.replace("`", "") +"_Index`   ( "+IndexString+" );");
-
+            st3.execute(
+                "ALTER TABLE `" + shortRchain.replace("`", "") + "_counts` " +
+                "ADD INDEX `" + shortRchain.replace("`", "") +"_Index` (" + IndexString + ");"
+            );
 
             //  close statements
             st2.close();
             st3.close();
-
-
         }
 
         rs.close();

--- a/src/BayesBaseH.java
+++ b/src/BayesBaseH.java
@@ -546,8 +546,19 @@ public class BayesBaseH {
 				String NoTuples="";
 				for(String id : rnode_ids) {
 					System.out.println("\nStarting Learning the BN Structure of rnode_ids: " + id+"\n");
+                    Statement mapping_st = con2.createStatement();
 					Statement st = con3.createStatement();
-					ResultSet rs = st.executeQuery("SELECT count(*) FROM `"+id.replace("`","")+"_CT`;"); // Oct 2nd, Why not check the csv file directly?  faster for larter CT? Oct 23
+                    ResultSet rnidMappingResult = mapping_st.executeQuery(
+                        "SELECT short_rnid " +
+                        "FROM lattice_mapping " +
+                        "WHERE lattice_mapping.orig_rnid = '" + id + "';"
+                    );
+                    rnidMappingResult.absolute(1);
+                    String short_rnid = rnidMappingResult.getString("short_rnid");
+                    ResultSet rs = st.executeQuery(
+                        "SELECT COUNT(*) " +
+                        "FROM `" + short_rnid.replace("`","") + "_CT`;"
+                    ); // Oct 2nd, Why not check the csv file directly?  faster for larger CT? Oct 23, Comment from: Unknown since lacking Git history.
 						while(rs.next()){
 							NoTuples = rs.getString(1);
 							System.out.println("NoTuples : " + NoTuples);

--- a/src/CP.java
+++ b/src/CP.java
@@ -82,6 +82,7 @@ public class CP {
     static String dbPassword="";
     static String dbaddress="";
     static String rchain;
+    static String shortRchain;
 
     public CP(String databaseName, String databaseName2) {
         CP.databaseName = databaseName;
@@ -254,7 +255,7 @@ public class CP {
         );
         ArrayList<String> noparent_tables = new ArrayList<String>();
 
-        String bigTable = rchain.substring(0, rchain.length() - 1) + "_CT`";
+        String bigTable = shortRchain.substring(0, shortRchain.length() - 1) + "_CT`";
         System.out.println("bigTable Name: " + bigTable + "\n");
         while(rst.next()) {
             System.out.println("noparent node: " + rst.getString(1));
@@ -370,7 +371,7 @@ public class CP {
         ResultSet rst = st.executeQuery("select distinct child FROM Path_BayesNets where Rchain = '" + rchain + "' and parent <> ''");
         ArrayList<String> hasparent_tables = new ArrayList<String>();
 
-        String bigTable = rchain.substring(0, rchain.length() - 1) + "_CT`";
+        String bigTable = shortRchain.substring(0, shortRchain.length() - 1) + "_CT`";
         // find name of contingency table that has the data we need for the chain
 
         while(rst.next()) {
@@ -611,10 +612,19 @@ public class CP {
         }
         con1 = DriverManager.getConnection(CONN_STR1, dbUsername, dbPassword);
         java.sql.Statement st = con1.createStatement();
-        ResultSet myrchain = st.executeQuery("select name as RChain from lattice_set where lattice_set.length = (SELECT max(length) FROM lattice_set);");
+        // TODO: Check to see if other queries are more efficient.
+        ResultSet myrchain = st.executeQuery(
+            "SELECT short_rnid AS short_RChain, orig_rnid AS RChain " +
+            "FROM lattice_set " +
+            "JOIN lattice_mapping " +
+            "ON lattice_set.name = lattice_mapping.orig_rnid " +
+            "WHERE lattice_set.length = (SELECT max(length) FROM lattice_set);"
+        );
         myrchain.absolute(1);
-        rchain = myrchain.getString(1);
+        rchain = myrchain.getString("RChain");
+        shortRchain = myrchain.getString("short_RChain");
         System.out.println("rchain: " + rchain + "\n");
+        System.out.println("short rchain: " + shortRchain + "\n");
         st.close();
     }
 }

--- a/src/CSVPrecomputor.java
+++ b/src/CSVPrecomputor.java
@@ -214,17 +214,25 @@ public class CSVPrecomputor {
 
 	public static void readRNodesFromLattice(int len) throws SQLException, IOException {
 		Statement st = con2.createStatement();
-		ResultSet rs = st.executeQuery("select name as RChain from lattice_set where lattice_set.length = " + len + ";");
+        ResultSet rs = st.executeQuery(
+            "SELECT short_rnid AS short_RChain, orig_rnid AS RChain " +
+            "FROM lattice_set " +
+            "JOIN lattice_mapping " +
+            "ON lattice_set.name = lattice_mapping.orig_rnid " +
+            "WHERE lattice_set.length = " + len + ";"
+        );
 		while(rs.next()){
 
-			//  get pvid for further use
-			String rchain = rs.getString("RChain");
-			System.out.println("\n RChain : " + rchain);
+            // Get the short and full form rnids for further use.
+            String rchain = rs.getString("RChain");
+            System.out.println("\n RChain : " + rchain);
+            String shortRchain = rs.getString("short_RChain");
+            System.out.println(" Short RChain : " + shortRchain);
 
 			//  create new statement
 			Statement st3 = con3.createStatement();
 			
-			String queryString= "SELECT * FROM `"+rchain.replace("`", "")+"_CT` where mult>0;";
+            String queryString= "SELECT * FROM `" + shortRchain.replace("`", "") + "_CT` WHERE MULT > 0;";
 			ResultSet rs5 = null;
 			try
 			{

--- a/src/scripts/metaqueries.sql
+++ b/src/scripts/metaqueries.sql
@@ -97,7 +97,11 @@ Now we make data join tables for each relationship functor node.
 
 INSERT into MetaQueries
 SELECT DISTINCT
-    short_rnid as Lattice_Point,'Counts' as TableType, 'FROM' as ClauseType, 'rtable' as EntryType, CONCAT('@database@.',R.TABLE_NAME, ' AS ', rnid) AS Entries
+    orig_rnid AS Lattice_Point,
+    'Counts' AS TableType,
+    'FROM' AS ClauseType,
+    'rtable' AS EntryType,
+    CONCAT('@database@.', R.TABLE_NAME, ' AS ', rnid) AS Entries
 FROM
     RNodes R, LatticeRNodes L 
 WHERE R.rnid = L.orig_rnid;
@@ -108,7 +112,10 @@ We need to replace the apostrophes in rnid to make the rnid a valid name for the
 
 INSERT into MetaQueries
 SELECT DISTINCT
-    short_rnid as Lattice_Point,'Counts' as TableType, 'FROM' as ClauseType, 'rtable' as EntryType,
+    orig_rnid AS Lattice_Point,
+    'Counts' AS TableType,
+    'FROM' AS ClauseType,
+    'rtable' AS EntryType,
     concat('(select "T" as ',
             rnid,
             ') as ',
@@ -121,7 +128,11 @@ WHERE R.rnid = L.orig_rnid;
 the ids in the population entity tables. **/
 
 INSERT into MetaQueries
-SELECT DISTINCT short_rnid as Lattice_Point,'Counts' as TableType, 'WHERE' as ClauseType, 'rtable' as EntryType,
+SELECT DISTINCT
+    orig_rnid AS Lattice_Point,
+    'Counts' AS TableType,
+    'WHERE' AS ClauseType,
+    'rtable' AS EntryType,
     CONCAT(rnid,
             '.',
             COLUMN_NAME,
@@ -142,13 +153,21 @@ WHERE R.rnid = L.orig_rnid;
 
 INSERT into MetaQueries
 select 
-    short_rnid as Lattice_Point, 'Counts' as TableType, 'SELECT' as ClauseType, 'rnid' as EntryType, orig_rnid AS Entries
+    orig_rnid AS Lattice_Point,
+    'Counts' AS TableType,
+    'SELECT' AS ClauseType,
+    'rnid' AS EntryType,
+    orig_rnid AS Entries
 from
     LatticeRNodes;
 
 INSERT into MetaQueries
 SELECT DISTINCT
-short_rnid as Lattice_Point, 'Counts' as TableType, 'SELECT' as ClauseType, '2nid' as EntryType, CONCAT(L.orig_rnid, '.', COLUMN_NAME, ' AS ', N.2nid) AS Entries
+    orig_rnid AS Lattice_Point,
+    'Counts' AS TableType,
+    'SELECT' AS ClauseType,
+    '2nid' AS EntryType,
+    CONCAT(L.orig_rnid, '.', COLUMN_NAME, ' AS ', N.2nid) AS Entries
 FROM
     LatticeRNodes L, RNodes_2Nodes RN, 2Nodes N
 where RN.rnid = L.orig_rnid and N.2nid = RN.2nid;
@@ -160,13 +179,21 @@ where RN.rnid = L.orig_rnid and N.2nid = RN.2nid;
 
 INSERT into MetaQueries
 select 
-    short_rnid as Lattice_Point, 'Counts' as TableType, 'GROUPBY' as ClauseType, 'rnid' as EntryType, orig_rnid AS Entries
+    orig_rnid AS Lattice_Point,
+    'Counts' AS TableType,
+    'GROUPBY' AS ClauseType,
+    'rnid' AS EntryType,
+    orig_rnid AS Entries
 from
     LatticeRNodes;
     
 INSERT into MetaQueries
 SELECT DISTINCT
-short_rnid as Lattice_Point, 'Counts' as TableType, 'GROUPBY' as ClauseType, '2nid' as EntryType, N.2nid AS Entries
+    orig_rnid AS Lattice_Point,
+    'Counts' AS TableType,
+    'GROUPBY' AS ClauseType,
+    '2nid' AS EntryType,
+    N.2nid AS Entries
 FROM
     LatticeRNodes L, RNodes_2Nodes RN, 2Nodes N
 where RN.rnid = L.orig_rnid and N.2nid = RN.2nid order by RN.rnid,COLUMN_NAME;
@@ -178,7 +205,13 @@ This includes the count(*) aggregation
 *************************************/
 
 INSERT into MetaQueries
-SELECT distinct short_rnid as Lattice_Point, TableType, ClauseType, EntryType, Entries FROM
+SELECT DISTINCT
+    orig_rnid AS Lattice_Point,
+    TableType,
+    ClauseType,
+    EntryType,
+    Entries
+FROM
     LatticeRNodes L, RNodes_pvars R, MetaQueries M
 WHERE
     L.orig_rnid = R.rnid and M.Lattice_Point = R.pvid;

--- a/src/scripts/metaqueries_RChain.sql
+++ b/src/scripts/metaqueries_RChain.sql
@@ -192,11 +192,15 @@ SELECT DISTINCT
     lattice_rel.removed as EntryType, 
     /** rnid = lattice_rel.removed should now point to the R_i of our paper **/
     /* a bit awkward to call it entry type */
-    concat('`',replace(lattice_rel.parent,'`',''),'_CT`')  AS Entries 
+    concat('`', replace(lattice_mapping.short_rnid, '`', ''), '_CT`') AS Entries
     /* current CT should be like conditioning on all other relationships being true */
     /* the parent represents the shortened Rchain */
 FROM
     lattice_rel
+JOIN
+    lattice_mapping
+ON
+    lattice_rel.parent = lattice_mapping.orig_rnid
 where 
     lattice_rel.parent <>'EmptySet';
     /* i.e. child = rchain has length > 1; */

--- a/src/scripts/metaqueries_RChain.sql
+++ b/src/scripts/metaqueries_RChain.sql
@@ -5,8 +5,16 @@ SET storage_engine=INNODB;
 /* set up the join tables that represent the case where a relationship is false and its attributes are undefined */
 
 INSERT into MetaQueries
-select distinct short_rnid as Lattice_Point, 'Join' as TableType, 'COLUMN' as ClauseType, '2nid' as EntryType, concat(2nid,
-' varchar(5)  default ',' "N/A" ') as Entries from RNodes_2Nodes N, LatticeRNodes L where N.rnid = L.orig_rnid;
+SELECT DISTINCT
+    orig_rnid as Lattice_Point,
+    'Join' as TableType,
+    'COLUMN' as ClauseType,
+    '2nid' as EntryType,
+    CONCAT(2nid, ' varchar(5)  default ', ' "N/A" ') AS Entries
+FROM
+    RNodes_2Nodes N, LatticeRNodes L
+WHERE
+    N.rnid = L.orig_rnid;
 
 /**************
  * Generating flat, star, and join tables for Rnodes
@@ -24,7 +32,10 @@ select distinct short_rnid as Lattice_Point, 'Join' as TableType, 'COLUMN' as Cl
  */
 INSERT into MetaQueries
 select DISTINCT 
-    short_rnid as Lattice_Point, 'Flat' as TableType, 'FROM' as ClauseType , 'table' as EntryType, 
+    orig_rnid AS Lattice_Point,
+    'Flat' AS TableType,
+    'FROM' AS ClauseType,
+    'table' AS EntryType,
     concat('`',replace(short_rnid, '`', ''),'_counts`') AS Entries
 from LatticeRNodes;
 
@@ -36,22 +47,38 @@ from LatticeRNodes;
 
 INSERT into MetaQueries
 SELECT distinct Lattice_Point, 'Flat' as TableType, ClauseType, EntryType, Entries
-FROM LatticeRNodes L, MetaQueries M where L.short_rnid = M.Lattice_Point and TableType = 'Counts' and ClauseType = 'GROUPBY'
-and EntryType <> 'rnid' and EntryType <> '2nid';
+FROM
+    LatticeRNodes L, MetaQueries M
+WHERE
+    L.orig_rnid = M.Lattice_Point
+    AND TableType = 'Counts'
+    AND ClauseType = 'GROUPBY'
+    AND EntryType <> 'rnid'
+    AND EntryType <> '2nid';
 
 /* use the same columns as in group by in select clause */
 
 INSERT into MetaQueries
 SELECT distinct Lattice_Point, 'Flat' as TableType, 'SELECT' AS ClauseType, EntryType, Entries
-FROM LatticeRNodes L, MetaQueries M where L.short_rnid = M.Lattice_Point and TableType = 'Counts' and ClauseType = 'GROUPBY'
-and EntryType <> 'rnid' and EntryType <> '2nid';
+FROM
+    LatticeRNodes L, MetaQueries M
+WHERE
+    L.orig_rnid = M.Lattice_Point
+    AND TableType = 'Counts'
+    AND ClauseType = 'GROUPBY'
+    AND EntryType <> 'rnid'
+    AND EntryType <> '2nid';
 
 /* sum over all the mults in the counts table 
  * 
  */
 INSERT into MetaQueries
-SELECT distinct short_rnid as Lattice_Point, 'Flat' as TableType, 'SELECT' AS ClauseType, 'aggregate' as EntryType,
-    concat('sum(`',replace(short_rnid, '`', ''),'_counts`.`MULT`)',' as "MULT"') AS Entries
+SELECT DISTINCT
+    orig_rnid AS Lattice_Point,
+    'Flat' AS TableType,
+    'SELECT' AS ClauseType,
+    'aggregate' AS EntryType,
+    CONCAT('SUM(`',REPLACE(short_rnid, '`', ''),'_counts`.`MULT`)',' as "MULT"') AS Entries
 from
     LatticeRNodes;
 
@@ -61,10 +88,18 @@ from
  */
 
 INSERT into MetaQueries
-SELECT distinct short_rnid as Lattice_Point, 'Star' as TableType, 'SELECT' as ClauseType, '1nid' as EntryType, Entries FROM
+SELECT DISTINCT
+    orig_rnid AS Lattice_Point,
+    'Star' AS TableType,
+    'SELECT' AS ClauseType,
+    '1nid' AS EntryType,
+    Entries
+FROM
     LatticeRNodes L, RNodes_pvars R, MetaQueries M
 WHERE
-    L.orig_rnid = R.rnid and M.Lattice_Point = R.pvid and ClauseType = 'GROUPBY';
+    L.orig_rnid = R.rnid
+    AND M.Lattice_Point = R.pvid
+    AND ClauseType = 'GROUPBY';
     
 /* Key condition: these fields must match the ones in the flat table. I.e. rnodes_counts - rnid, 1nid, multi = union of group by from pvariables
  * 
@@ -80,7 +115,11 @@ select (t1.mult * t2.mult * t3.mult) as "MULT". Currently done in code
  * insert all count tables from associated populations in from list for join
  */
 INSERT into MetaQueries
-SELECT DISTINCT short_rnid as Lattice_Point, 'Star' as TableType, 'FROM' as ClauseType, 'table' as EntryType, 
+SELECT DISTINCT
+    orig_rnid AS Lattice_Point,
+    'Star' AS TableType,
+    'FROM' AS ClauseType,
+    'table' AS EntryType,
 concat('`',replace(pvid, '`', ''),'_counts`')
     AS Entries FROM
     LatticeRNodes L, RNodes_pvars R
@@ -143,7 +182,7 @@ select  distinct
 from 
     lattice_membership M, LatticeRNodes L, RNodes_pvars R
 where 
-    R.rnid = L.orig_rnid and L.short_rnid = M.member;
+    R.rnid = L.orig_rnid AND L.orig_rnid = M.member;
     
 insert into MetaQueries
 SELECT DISTINCT 
@@ -173,7 +212,10 @@ concat('`',replace(R.pvid, '`', ''),'_counts`')    AS Entries
 /* should check that this includes expansion for pvid = course 0 */
 FROM
     lattice_rel LR, LatticeRNodes L, RNodes_pvars R
-where LR.parent <>'EmptySet' and LR.removed = L.short_rnid and L.orig_rnid = R.rnid and
+WHERE
+    LR.parent <> 'EmptySet'
+    AND LR.removed = L.orig_rnid
+    AND L.orig_rnid = R.rnid AND
 R.pvid not in (select pvid from RChain_pvars where RChain_pvars.rchain = LR.parent);
 /* this seems to implement the "differing first-order variable rule" from the paper */
 /* find pvids that are associated with the removed rnode but not with the shortened rchain = parent */
@@ -198,7 +240,7 @@ where
     and  lattice_membership.member > lattice_rel.removed
     /* going through rnids in order, find the rows in current CT-table where the remaining rnids are true */
     and lattice_rel.parent <>'EmptySet'
-    and L.short_rnid = lattice_membership.member;
+    AND L.orig_rnid = lattice_membership.member;
 
 /****************
  * now the select clause. This finds the group by columns for all rnids in the shortened parent rchain
@@ -236,7 +278,10 @@ SELECT DISTINCT
 FROM
     lattice_rel LR, LatticeRNodes L, RNodes_pvars R,
     MetaQueries M
-where LR.parent <>'EmptySet' and LR.removed = L.short_rnid and L.orig_rnid = R.rnid and
+WHERE
+    LR.parent <> 'EmptySet'
+    AND LR.removed = L.orig_rnid
+    AND L.orig_rnid = R.rnid AND
 R.pvid not in (select pvid from RChain_pvars where RChain_pvars.rchain = LR.parent)
 AND M.Lattice_Point = R.pvid
 AND M.ClauseType = 'GROUPBY'


### PR DESCRIPTION
- The method readFirstSets() was updated to retrieve the full form
  rnids instead of the short form.
- Updated the method mapping_rnid() so that it now maps from a given
  full form rnid to the associated short form instead of from a given
  short form rnid to the associated full form.
- Also adjusted the white-space of lines of code that I modified, i.e.
  removed any mixture of tabs and spaces and replaced them with
  spaces.