### PR TITLE
Corrected query for the deletion of intermediate tables.

### DIFF
--- a/src/KeepTablesOnly.java
+++ b/src/KeepTablesOnly.java
@@ -58,7 +58,16 @@ public class KeepTablesOnly{
 	//Subject to change as per nee dfor tables in CT database
 	public static ArrayList<String> findLongestRChain() throws SQLException{
 		Statement st = con_BN.createStatement();
-		ResultSet rst = st.executeQuery("SELECT name FROM lattice_set;");
+		ResultSet rst = st.executeQuery(
+			"SELECT short_rnid AS name " +
+			"FROM lattice_set " +
+			"JOIN lattice_mapping " +
+			"ON lattice_set.name = lattice_mapping.orig_rnid " +
+			"WHERE lattice_set.length =	(" +
+				"SELECT MAX(length) " +
+				"FROM lattice_set" +
+			");"
+		);
 		ArrayList<String> sets = new ArrayList<String>();
 		while(rst.next()){
 			System.out.println(rst.getString("name"));


### PR DESCRIPTION
- The query in the findLongestRChain() method in KeepTablesOnly.java
  didn't take the length of the RChain into consideration so the query
  was updated to consider the length as well as get the correct table
  names, which should be the short form rnid instead of the full form
  rnid.