### PR TITLE
Updated the index for the "pairs" tables to use a "unique" constraint.

### DIFF
--- a/factorbase/src/main/java/ca/sfu/cs/factorbase/tables/KLD_generator.java
+++ b/factorbase/src/main/java/ca/sfu/cs/factorbase/tables/KLD_generator.java
@@ -328,7 +328,7 @@ public class KLD_generator {
 		st.execute(createclause);
 		
 		//add index to all columns in pair table
-		String index_p = "alter table " + name + " add index " + name + "( MULT ASC";
+		String index_p = "alter table " + name + " add unique index " + name + "( MULT ASC";
 		for (int i=0; i<list.size(); ++i) {
 			index_p = index_p + ", `" + list.get(i) + "` ASC";
 		}


### PR DESCRIPTION
- Prior to this change, only a subset of the columns were being
  indexed on which could potential introduce duplicates when
  generating the indices.  Added a "unique" constraint when generating
  the indices.