### PR TITLE
Removed the "rnid" column from the lattice_membership table.

### DIFF
--- a/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/short_rnid_LatticeGenerator.java
+++ b/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/short_rnid_LatticeGenerator.java
@@ -139,7 +139,7 @@ public class short_rnid_LatticeGenerator {
         maxNumberOfMembers = firstSets.size();
         Statement st = con2.createStatement();
     
-        st.execute("create table if not exists lattice_membership (name VARCHAR(398), member VARCHAR(398), rnid VARCHAR(199), PRIMARY KEY (name, member));");
+        st.execute("create table if not exists lattice_membership (name VARCHAR(398), member VARCHAR(398), PRIMARY KEY (name, member));");
         st.execute("create table if not exists lattice_rel (parent VARCHAR(398), child VARCHAR(398), removed VARCHAR(199), rnid VARCHAR(199), PRIMARY KEY (parent, child));");
         st.execute("create table if not exists lattice_set (name VARCHAR(199), length INT(11), PRIMARY KEY (name, length));");
 

--- a/factorbase/src/main/resources/scripts/model_manager.sql
+++ b/factorbase/src/main/resources/scripts/model_manager.sql
@@ -69,7 +69,7 @@ SELECT DISTINCT lattice_membership.name AS Rchain, Fid AS node
         lattice_membership,
         RNodes_BN_Nodes
     WHERE
-        RNodes_BN_Nodes.rnid = lattice_membership.rnid
+        RNodes_BN_Nodes.rnid = lattice_membership.member
     ORDER BY lattice_membership.name;
 
 ALTER TABLE Path_BN_nodes ADD INDEX `HashIndex`  (`Rchain`,`node`); /* May 7*/
@@ -127,7 +127,7 @@ from
     2Nodes,
     lattice_membership
 where
-    lattice_membership.rnid = RNodes.rnid
+    lattice_membership.member = RNodes.rnid
         and RNodes.pvid1 = 2Nodes.pvid1
         and RNodes.pvid2 = 2Nodes.pvid2
         and RNodes.TABLE_NAME = 2Nodes.TABLE_NAME


### PR DESCRIPTION
- Removed the "rnid" column from the lattice_membership table and
  made all references to that column use the "member" column instead.
  This is safe to do now because the values in the "member" column
  are using the full RNID instead of the short RNID.
- This should fix the issue where some arrows are missing in the Bayes
  Net that gets generated by FactorBase.

GitHub Issue: https://github.com/sfu-cl-lab/FactorBase/issues/81