### PR TITLE
Update the index of temp table to delete the fisrt column of `parsum` in indexUpdate temp1 index

### DIFF
--- a/factorbase/src/main/java/ca/sfu/cs/factorbase/tables/KLD_generator.java
+++ b/factorbase/src/main/java/ca/sfu/cs/factorbase/tables/KLD_generator.java
@@ -494,7 +494,7 @@ public class KLD_generator {
 
         st.execute(query1);
 
-        // Add index to temp1 (parsum and all parents).
+        // Add index to temp1 (all parents).
         String index_t = "ALTER TABLE temp1 ADD INDEX temp1( `" + list.get(1) + "` ASC";
         for (int i = 2; i < list.size(); ++i) {
             index_t = index_t + ", `" + list.get(i) + "` ASC";

--- a/factorbase/src/main/java/ca/sfu/cs/factorbase/tables/KLD_generator.java
+++ b/factorbase/src/main/java/ca/sfu/cs/factorbase/tables/KLD_generator.java
@@ -495,11 +495,12 @@ public class KLD_generator {
         st.execute(query1);
 
         // Add index to temp1 (parsum and all parents).
-        String index_t = "ALTER TABLE temp1 ADD INDEX temp1(`parsum` ASC";
-        for (int i = 1; i < list.size(); ++i) {
+        String index_t = "ALTER TABLE temp1 ADD INDEX temp1( `" + list.get(1) + "` ASC";
+        for (int i = 2; i < list.size(); ++i) {
             index_t = index_t + ", `" + list.get(i) + "` ASC";
         }
         index_t = index_t + ");";
+        System.out.println("queryIndex: "+ index_t);
         st.execute(index_t);
 
         // zqian@ Oct 21, 2013, Bottleneck??


### PR DESCRIPTION
- Updated the index of `temp1` table, deleted the fisrt column of `parsum` in index because `parsum` is not used in the update where clause later, which will cause the index unable to work due to the leftmost matching principle in mysql query.
- This speeds up the update query following and fixs the problem that the update query takes quite a long time in big datasets.