### PR TITLE
Removed an unused table that is generated by FactorBase.

### DIFF
--- a/code/factorbase/src/main/resources/scripts/transfer.sql
+++ b/code/factorbase/src/main/resources/scripts/transfer.sql
@@ -7,9 +7,6 @@ create schema @database@_BN;
 DROP SCHEMA IF EXISTS @database@_CT; 
 create schema @database@_CT;
 
-DROP SCHEMA IF EXISTS @database@_convert_CT; 
-create schema @database@_convert_CT;
-
 USE @database@_BN;
 SET storage_engine=INNODB;
 
@@ -161,5 +158,3 @@ create table lattice_set as select * from  @database@_setup.lattice_set;
 create table Path_Aux_Edges as select * from  @database@_setup.Path_Aux_Edges;
 create table SchemaEdges as select * from  @database@_setup.SchemaEdges;
 */
-
-

--- a/travis-resources/dbdump.sh
+++ b/travis-resources/dbdump.sh
@@ -34,7 +34,7 @@ fi
 
 any_failure=0
 
-for database in "${name}_BN" "${name}_CT" "${name}_convert_CT" "${name}_setup"
+for database in "${name}_BN" "${name}_CT" "${name}_setup"
 do
   extractionFailed=0
   echo "Now extracting tables in database: $database..."


### PR DESCRIPTION
- The table <database>_convert_CT is created by FactorBase, but we
  don't seem to use it for anything so removing it from the
  transfer.sql script.