### PR TITLE
Refactor sortmerge3

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/QueryGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/QueryGenerator.java
@@ -18,6 +18,7 @@ public final class QueryGenerator {
     private QueryGenerator() {
     }
 
+
     /**
      * Generate the String used to join rows between tableA and tableB.
      *
@@ -35,6 +36,7 @@ public final class QueryGenerator {
 
         return String.join(" AND ", conditions);
     }
+
 
     /**
      * Generates a MySQL SELECT String that returns the items in tableA that are not in tableB.
@@ -56,6 +58,7 @@ public final class QueryGenerator {
                 "WHERE " + whereClauseJoin +
             ")";
     }
+
 
     /**
      * Generates a MySQL SELECT String that returns the items for the specified table that have a column
@@ -79,6 +82,31 @@ public final class QueryGenerator {
 
         builder.append(quotedCSV.toString());
         builder.append(")");
+
+        return builder.toString();
+    }
+
+
+    /**
+     * Generates a MySQL INSERT String for a PreparedStatement that inserts into the given table with the
+     * specified number of columns.
+     *
+     * @param tableName - the table to insert the values into.
+     * @param numberOfColumns - the number of columns for each row in the given table.
+     * @return a String that can be used in a PreparedStatement to insert values into the specified table.
+     */
+    public static String createSimplePreparedInsertQuery(String tableName, int numberOfColumns) {
+        StringBuilder builder = new StringBuilder("INSERT INTO ");
+        builder.append(tableName);
+        builder.append(" VALUES (");
+
+        StringJoiner questionMarkCSV = new StringJoiner(",");
+        for (int i = 0; i < numberOfColumns; i++) {
+            questionMarkCSV.add("?");
+        }
+
+        builder.append(questionMarkCSV.toString());
+        builder.append(");");
 
         return builder.toString();
     }

--- a/code/factorbase/src/test/java/ca/sfu/cs/factorbase/util/QueryGeneratorTest.java
+++ b/code/factorbase/src/test/java/ca/sfu/cs/factorbase/util/QueryGeneratorTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -51,6 +52,7 @@ public class QueryGeneratorTest {
         st = null;
     }
 
+
     @Test
     public void createDifferenceQuery_ReturnsCorrectResults() throws SQLException {
         String query = QueryGenerator.createDifferenceQuery(
@@ -90,6 +92,7 @@ public class QueryGeneratorTest {
         rs.close();
     }
 
+
     @Test
     public void createSimpleInQuery_ReturnsCorrectResults_WhenSingleMatch() throws SQLException {
         String query = QueryGenerator.createSimpleInQuery(
@@ -107,6 +110,7 @@ public class QueryGeneratorTest {
 
         rs.close();
     }
+
 
     @Test
     public void createSimpleInQuery_ReturnsCorrectResults_WhenMultipleMatches() throws SQLException {
@@ -137,5 +141,38 @@ public class QueryGeneratorTest {
         assertThat(count, equalTo(3));
 
         rs.close();
+    }
+
+
+    @Test
+    public void createSimplePreparedInsertQuery_ReturnsCorrectResults() throws SQLException {
+        String query = QueryGenerator.createSimplePreparedInsertQuery("test_inserts", 3);
+
+        PreparedStatement ps = db.con.prepareStatement(query);
+
+        addToBatch(ps, 1, "text input", true);
+        addToBatch(ps, 2, "more input", false);
+
+        int[] results = ps.executeBatch();
+
+        assertThat(results.length, equalTo(2));
+    }
+
+
+    /**
+     * Helper method to add queries to a prepared statement that will be executed as a batch.
+     *
+     * @param ps - PreparedStatement to add a query to.
+     * @param intValue - the Integer value to set for the query.
+     * @param strValue - the string value to set for the query.
+     * @param boolValue - the Boolean value to set for the query.
+     * @throws SQLException if adding to the batch fails.
+     */
+    private void addToBatch(PreparedStatement ps, int intValue, String strValue, boolean boolValue) throws SQLException {
+        ps.setInt(1, intValue);
+        ps.setString(2, strValue);
+        ps.setBoolean(3, boolValue);
+        ps.addBatch();
+        ps.clearParameters();
     }
 }

--- a/travis-resources/tests-database.sql
+++ b/travis-resources/tests-database.sql
@@ -121,6 +121,29 @@ LOCK TABLES `t2` WRITE;
 INSERT INTO `t2` VALUES ('B',NULL,NULL),('C',1,2),('Jack',3,1),('Kim2',2,NULL);
 /*!40000 ALTER TABLE `t2` ENABLE KEYS */;
 UNLOCK TABLES;
+
+--
+-- Table structure for table `test_inserts`
+--
+
+DROP TABLE IF EXISTS `test_inserts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `test_inserts` (
+  `int_col` int(11) DEFAULT NULL,
+  `str_col` varchar(32) DEFAULT NULL,
+  `bool_col` tinyint(1) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `test_inserts`
+--
+
+LOCK TABLES `test_inserts` WRITE;
+/*!40000 ALTER TABLE `test_inserts` DISABLE KEYS */;
+/*!40000 ALTER TABLE `test_inserts` ENABLE KEYS */;
+UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;


### PR DESCRIPTION
Prior to this change, we were writing the results of the sort merge to a file and then loading this file into the database.  This seems inefficient as we are transferring the same data twice.

I suspect we didn't try using PreparedStatements with batch updates, which is why we did this double data transfer (we most likely tried to do inserts unbatched, where each would be in a seperate transaction, making this process slow).  In this pull request, we now write directly to the database using PreparedStatements with batch updates.

I will try running the code on IMDB MovieLens to see how the performance changes before we put this in.

Please read the commit messages for details of what was changed.