### PR TITLE
Updated sort merge join to be a hash join instead.

### DIFF
--- a/code/factorbase/src/test/java/ca/sfu/cs/factorbase/tables/Sort_merge3Test.java
+++ b/code/factorbase/src/test/java/ca/sfu/cs/factorbase/tables/Sort_merge3Test.java
@@ -48,14 +48,14 @@ public class Sort_merge3Test {
                 assertThat(attribute2, equalTo("match2"));
                 break;
             case 1:
-                assertThat(mult, equalTo(100));
-                assertThat(attribute1, equalTo("match1"));
-                assertThat(attribute2, equalTo("miss1"));
-                break;
-            case 2:
                 assertThat(mult, equalTo(996));
                 assertThat(attribute1, equalTo("match3"));
                 assertThat(attribute2, equalTo("match4"));
+                break;
+            case 2:
+                assertThat(mult, equalTo(100));
+                assertThat(attribute1, equalTo("match1"));
+                assertThat(attribute2, equalTo("miss1"));
                 break;
             case 3:
                 assertThat(mult, equalTo(10));


### PR DESCRIPTION
Sort merge join seems expensive since we have to sort two tables on all columns (except for MULT) in order to join them so a hash join implementation was created to see if avoiding the sorting would help with performance.

I have done some quick run time tests using the components runner and we went from run times that looked like:
```
788576 ms
726840 ms
```
which is about 12 - 13 minutes, to run times like:
```
329224 ms
311144 ms
```
which is about 5 minutes.

I'm still running FactorBase on IMDB_MovieLens and will post the results here, but with these component results it looks like we can expect there to be further improvements in performance :slightly_smiling_face: 