### PR TITLE
[deadcode] Removed the unused column "rnid" from the lattice_rel table.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/short_rnid_LatticeGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/short_rnid_LatticeGenerator.java
@@ -90,7 +90,7 @@ public class short_rnid_LatticeGenerator {
         Statement st = dbConnection.createStatement();
 
         st.execute("CREATE TABLE IF NOT EXISTS lattice_membership (name VARCHAR(398), member VARCHAR(398), PRIMARY KEY(name, member));");
-        st.execute("CREATE TABLE IF NOT EXISTS lattice_rel (parent VARCHAR(398), child VARCHAR(398), removed VARCHAR(199), rnid VARCHAR(199), PRIMARY KEY(parent, child));");
+        st.execute("CREATE TABLE IF NOT EXISTS lattice_rel (parent VARCHAR(398), child VARCHAR(398), removed VARCHAR(199), PRIMARY KEY(parent, child));");
         st.execute("CREATE TABLE IF NOT EXISTS lattice_set (name VARCHAR(199), length INT(11), PRIMARY KEY(name, length));");
 
         st.execute("TRUNCATE lattice_rel;");

--- a/travis-resources/expected-output/mysql-extraction.txt
+++ b/travis-resources/expected-output/mysql-extraction.txt
@@ -1213,11 +1213,11 @@ name	member
 `RA(prof0,student0),registration(course0,student0)`	`registration(course0,student0)`
 `registration(course0,student0)`	`registration(course0,student0)`
 Table: lattice_rel
-EmptySet	`RA(prof0,student0)`	`RA(prof0,student0)`	NULL
-EmptySet	`registration(course0,student0)`	`registration(course0,student0)`	NULL
-parent	child	removed	rnid
-`RA(prof0,student0)`	`RA(prof0,student0),registration(course0,student0)`	`registration(course0,student0)`	NULL
-`registration(course0,student0)`	`RA(prof0,student0),registration(course0,student0)`	`RA(prof0,student0)`	NULL
+EmptySet	`RA(prof0,student0)`	`RA(prof0,student0)`
+EmptySet	`registration(course0,student0)`	`registration(course0,student0)`
+parent	child	removed
+`RA(prof0,student0)`	`RA(prof0,student0),registration(course0,student0)`	`registration(course0,student0)`
+`registration(course0,student0)`	`RA(prof0,student0),registration(course0,student0)`	`RA(prof0,student0)`
 Table: lattice_set
 name	length
 `RA(prof0,student0)`	1


### PR DESCRIPTION
- The column "rnid" of the lattice_rel table seems to always be NULL
  and unused, so removing it from the table.