### PR TITLE
Cleanup logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 addons:
   mariadb: '10.0'
 jdk:

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/exporter/bifexporter/BIF_Generator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/exporter/bifexporter/BIF_Generator.java
@@ -43,7 +43,7 @@ public class BIF_Generator {
 
 
     public static void generate_bif(String network_name, String bif_file_name_withPath, Connection con) throws SQLException, IOException {
-        logger.info("\n BIF Generator starts");
+        logger.fine("\nBIF Generator starts");
 
         Statement st = (Statement) con.createStatement();
         File file = new File(bif_file_name_withPath);
@@ -207,7 +207,7 @@ public class BIF_Generator {
         output.write(writeNetworkEnd());
         output.close();
         st.close();
-        logger.info("BIF Generator Ends for " + network_name);
+        logger.fine("BIF Generator Ends for " + network_name);
     }
 
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/jbn/BayesNet_Learning_main.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/jbn/BayesNet_Learning_main.java
@@ -58,8 +58,6 @@ public class BayesNet_Learning_main {
             }
         }
 
-        System.out.println(knowledge);
-        System.out.println("knowledge is DONE~~");
         gesSearch.setKnowledge(knowledge);
 
         /* learn a dag from data */
@@ -68,8 +66,6 @@ public class BayesNet_Learning_main {
 
         PatternToDag p2d = new PatternToDag(pattern);
         Graph dag = p2d.patternToDagMeek();
-
-        System.out.println("DAG is DONE~~~");
 
         // Output dag into Bayes Interchange format.
         FileWriter fstream = new FileWriter(destfile);

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/short_rnid_LatticeGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/short_rnid_LatticeGenerator.java
@@ -27,8 +27,6 @@ public class short_rnid_LatticeGenerator {
         // Connect to db using jdbc.
         Statement tempst = dbConnection.createStatement();
 
-        logger.info("Enter into short lattice generate.");
-
         // Generate shorter rnid, from a to z.
         int fc = 97;
         char short_rnid;

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseCT_SortMerge.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseCT_SortMerge.java
@@ -86,9 +86,6 @@ public class BayesBaseCT_SortMerge {
         // rnid mapping. maxNumberofMembers = maximum size of lattice element. Should be called LatticeHeight
         maxNumberOfMembers = short_rnid_LatticeGenerator.generate(con_BN);
 
-
-        logger.info(" ##### lattice is ready for use* ");
-
 // may not need to run this script any more, using LatticeRnodes table OS August 25, 2017//
        // bzsr.runScript("scripts/add_orig_rnid.sql");
        // add_orig_rnid should be superseded by using Lattice Rnodes table in metaqueries script
@@ -160,7 +157,7 @@ public class BayesBaseCT_SortMerge {
                 BuildCT_Rnodes_counts(len);
             }
             long l2 = System.currentTimeMillis(); //@zqian : measure structure learning time
-            logger.info("Building Time(ms) for Rnodes_counts: "+(l2-l_1)+" ms.\n");
+            logger.fine("Building Time(ms) for Rnodes_counts: "+(l2-l_1)+" ms.\n");
         }
         else {
             logger.warning("link off !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
@@ -175,7 +172,6 @@ public class BayesBaseCT_SortMerge {
             // handling Rnodes with Lattice Moebius Transform
             //initialize first level of rchain lattice
             for(int len = 1; len <= 1; len++) {
-                logger.info("Building Time(ms) for Rchain =1 \n");
                 //building the _flat tables
                 BuildCT_Rnodes_flat(len);
         
@@ -189,10 +185,10 @@ public class BayesBaseCT_SortMerge {
             //building the _CT tables. Going up the Rchain lattice
             for(int len = 2; len <= maxNumberOfMembers; len++)
             { 
-                logger.info("now we're here for Rchain!");
-                logger.info("Building Time(ms) for Rchain >=2 \n");
+                logger.fine("now we're here for Rchain!");
+                logger.fine("Building Time(ms) for Rchain >=2 \n");
                 BuildCT_RChain_flat(len);
-                logger.info(" Rchain! are done");
+                logger.fine(" Rchain! are done");
             }
         }
         
@@ -229,7 +225,7 @@ public class BayesBaseCT_SortMerge {
         }
         
         long l2 = System.currentTimeMillis();  //@zqian
-        logger.info("Building Time(ms) for ALL CT tables:  "+(l2-l)+" ms.\n");
+        logger.fine("Building Time(ms) for ALL CT tables:  "+(l2-l)+" ms.\n");
     }
 
     /**
@@ -271,7 +267,7 @@ public class BayesBaseCT_SortMerge {
      * @throws  IOException
      */
     private static void BuildCT_RChain_flat(int len) throws SQLException, IOException {
-        logger.info("\n ****************** \n" +
+        logger.fine("\n ****************** \n" +
                 "Building the _CT tables for Length = "+len +"\n" );
 
 //        long l = System.currentTimeMillis();
@@ -373,7 +369,7 @@ public class BayesBaseCT_SortMerge {
                 //logger.fine("alter table "+cur_star_Table+" add index "+cur_star_Table+"   ( "+IndexString+" );");
                 st3.execute("alter table "+cur_star_Table+" add index "+cur_star_Table+"   ( "+IndexString+" );");       
                 long l3 = System.currentTimeMillis(); 
-                logger.info("Building Time(ms) for "+cur_star_Table+ " : "+(l3-l2)+" ms.\n");
+                logger.fine("Building Time(ms) for "+cur_star_Table+ " : "+(l3-l2)+" ms.\n");
                 //staring to create the _flat table
                 // Oct 16 2013
                 // here is the wrong version that always uses _counts table to generate the _flat table. 
@@ -396,7 +392,7 @@ public class BayesBaseCT_SortMerge {
                 //logger.fine("alter table "+cur_flat_Table+" add index "+cur_flat_Table+"   ( "+IndexString2+" );");
                 st3.execute("alter table "+cur_flat_Table+" add index "+cur_flat_Table+"   ( "+IndexString2+" );");
                 long l4 = System.currentTimeMillis(); 
-                logger.info("Building Time(ms) for "+cur_flat_Table+ " : "+(l4-l3)+" ms.\n");
+                logger.fine("Building Time(ms) for "+cur_flat_Table+ " : "+(l4-l3)+" ms.\n");
                 /**********starting to create _flase table***using sort_merge*******************************/
                 // starting to create _flase table : part1
                 String cur_false_Table = "`" + removedShort.replace("`", "") + len + "_" + fc + "_false`";
@@ -416,7 +412,7 @@ public class BayesBaseCT_SortMerge {
                 //logger.fine("alter table "+cur_false_Table+" add index "+cur_false_Table+"   ( "+IndexString3+" );");
                 st3.execute("alter table "+cur_false_Table+" add index "+cur_false_Table+"   ( "+IndexString3+" );");       
                 long l5 = System.currentTimeMillis(); 
-                logger.info("Building Time(ms) for "+cur_false_Table+ " : "+(l5-l4)+" ms.\n");
+                logger.fine("Building Time(ms) for "+cur_false_Table+ " : "+(l5-l4)+" ms.\n");
          
                 // staring to create the CT table
                 ResultSet rs_45 = st2.executeQuery("select column_name as Entries from information_schema.columns where table_schema = '"+databaseName_CT+"' and table_name = '"+cur_CT_Table.replace("`","")+"';");
@@ -459,7 +455,7 @@ public class BayesBaseCT_SortMerge {
                 st2.close();            
                 st3.close();
                 long l6 = System.currentTimeMillis(); 
-                logger.info("Building Time(ms) for "+cur_CT_Table+ " : "+(l6-l5)+" ms.\n");
+                logger.fine("Building Time(ms) for "+cur_CT_Table+ " : "+(l6-l5)+" ms.\n");
             }
             st1.close();
             rs1.close();
@@ -469,7 +465,7 @@ public class BayesBaseCT_SortMerge {
         st.close();
 //        long l2 = System.currentTimeMillis(); //@zqian : measure structure learning time
         //System.out.print("Building Time(ms): "+(l2-l)+" ms.\n");
-        logger.info("\n Build CT_RChain_TABLES for length = "+len+" are DONE \n" );
+        logger.fine("\n Build CT_RChain_TABLES for length = "+len+" are DONE \n" );
     }
 
     /* building pvars_counts*/
@@ -554,8 +550,8 @@ public class BayesBaseCT_SortMerge {
         rs.close();
         st.close();
         long l2 = System.currentTimeMillis(); //@zqian : measure structure learning time
-        logger.info("Building Time(ms) for Pvariables counts: "+(l2-l)+" ms.\n");
-        logger.info("\n Pvariables are DONE \n" );
+        logger.fine("Building Time(ms) for Pvariables counts: "+(l2-l)+" ms.\n");
+        logger.fine("\n Pvariables are DONE \n" );
     }
 
     /**
@@ -645,7 +641,7 @@ public class BayesBaseCT_SortMerge {
         rs.close();
         st.close();
 
-        logger.info("\n Rnodes_counts are DONE \n" );
+        logger.fine("\n Rnodes_counts are DONE \n" );
     }
 
     /**
@@ -730,7 +726,7 @@ public class BayesBaseCT_SortMerge {
 
         rs.close();
         st.close();
-        logger.info("\n Rnodes_counts are DONE \n" );
+        logger.fine("\n Rnodes_counts are DONE \n" );
     }
 
     /**
@@ -812,8 +808,8 @@ public class BayesBaseCT_SortMerge {
         rs.close();
         st.close();
         long l2 = System.currentTimeMillis(); //@zqian : measure structure learning time
-        logger.info("Building Time(ms) for Rnodes_flat: "+(l2-l)+" ms.\n");
-        logger.info("\n Rnodes_flat are DONE \n" );
+        logger.fine("Building Time(ms) for Rnodes_flat: "+(l2-l)+" ms.\n");
+        logger.fine("\n Rnodes_flat are DONE \n" );
     }
 
     /**
@@ -901,8 +897,8 @@ public class BayesBaseCT_SortMerge {
         rs.close();
         st.close();
         long l2 = System.currentTimeMillis(); //@zqian : measure structure learning time
-        logger.info("Building Time(ms) for Rnodes_star: "+(l2-l)+" ms.\n");
-        logger.info("\n Rnodes_star are DONE \n" );
+        logger.fine("Building Time(ms) for Rnodes_star: "+(l2-l)+" ms.\n");
+        logger.fine("\n Rnodes_star are DONE \n" );
     }
 
     /**
@@ -1002,8 +998,8 @@ public class BayesBaseCT_SortMerge {
         rs.close();
         st.close();
         long l2 = System.currentTimeMillis(); //@zqian : measure structure learning time
-        logger.info("Building Time(ms) for Rnodes_false and Rnodes_CT: "+(l2-l)+" ms.\n");
-        logger.info("\n Rnodes_false and Rnodes_CT  are DONE \n" );
+        logger.fine("Building Time(ms) for Rnodes_false and Rnodes_CT: "+(l2-l)+" ms.\n");
+        logger.fine("\n Rnodes_false and Rnodes_CT  are DONE \n" );
     }
 
     /**
@@ -1055,7 +1051,7 @@ public class BayesBaseCT_SortMerge {
         }
         rs.close();
         st.close();
-        logger.info("\n Rnodes_joins are DONE \n" );
+        logger.fine("\n Rnodes_joins are DONE \n" );
     }
 
     /**

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
@@ -105,7 +105,6 @@ public class BayesBaseH {
         ResultSet rst1 = st.executeQuery("SELECT name FROM lattice_set WHERE length = " + maxNumberOfMembers + ";");
         rst1.absolute(1);
         rchain = rst1.getString(1);
-        logger.info(" ##### lattice is ready for use* "); // @zqian
 
         // Structure learning.
         StructureLearning(database, con2);
@@ -115,7 +114,7 @@ public class BayesBaseH {
          * it can happen that a node has no edge at all, not even with an empty parent. In that case the Bif generator gets messed up. So we catch such
          * orphaned nodes in the next statement.
          */
-        logger.info("Inserting the Missing Fid as Child into Path_Bayes_Nets \n");
+        logger.fine("Inserting the Missing Fid as Child into Path_Bayes_Nets \n");
         st.execute(
             "INSERT IGNORE INTO Path_BayesNets " +
             "SELECT '" + rchain + "' AS Rchain, Fid AS child, '' AS parent " +
@@ -134,7 +133,7 @@ public class BayesBaseH {
         // Continuous
         if (!cont.equals("1")) {
             // Now compute conditional probability estimates and write them to @database@_BN.
-            logger.info("\n Structure Learning is DONE.  ready for parameter learning."); //@zqian
+            logger.fine("\n Structure Learning is DONE.  ready for parameter learning."); //@zqian
 
             // Export the final result to xml.  We assume that there is a single largest relationship chain and write the Bayes net for that relationship chain to xml.
             // Only export the structure, prepare for the pruning phase, Oct 23, 2013.
@@ -142,13 +141,13 @@ public class BayesBaseH {
 
             //      @zqian  for TestScoreComputation, use local ct to compute local CP.
             if (Flag_UseLocal_CT) {
-                logger.info("\n For BN_ScoreComputation.  use local_CT to compute the local_CP.");
+                logger.fine("\n For BN_ScoreComputation.  use local_CT to compute the local_CP.");
             } else {
                 // For FunctorWrapper, do NOT have to use the local_CT, or HAVE TO change the weight learning part. June 18 2014.
                 CPGenerator.Generator(databaseName, con2); // May 22, 2014 zqian, computing the score for link analysis off.
                 CP mycp = new CP(databaseName2, databaseName3);
                 mycp.cp();
-                logger.info("\n Parameter learning is done.");
+                logger.fine("\n Parameter learning is done.");
                 //  For FunctorWrapper
             }
 
@@ -158,10 +157,10 @@ public class BayesBaseH {
             long l = System.currentTimeMillis(); // @zqian: measure structure learning time
 
             if (opt3.equals("1")) {
-                logger.info("\n KLD_generator.KLDGenerator.");
+                logger.fine("\n KLD_generator.KLDGenerator.");
                 KLD_generator.KLDGenerator(databaseName, con2);
             } else {
-                logger.info("\n KLD_generator.smoothed_CP.");
+                logger.fine("\n KLD_generator.smoothed_CP.");
                 KLD_generator.smoothed_CP(rchain, con2);
             }
 
@@ -170,9 +169,9 @@ public class BayesBaseH {
             BIF_Generator.generate_bif(databaseName, "Bif_" + databaseName + ".xml", con2);
 
             long l2 = System.currentTimeMillis(); // @zqian: measure structure learning time.
-            logger.info("smoothed_CP Time(ms): " + (l2 - l) + " ms.\n");
+            logger.fine("smoothed_CP Time(ms): " + (l2 - l) + " ms.\n");
         } else {
-            logger.info("\n Structure Learning is DONE. \n NO parameter learning for Continuous data."); // @zqian
+            logger.fine("\n Structure Learning is DONE. \n NO parameter learning for Continuous data."); // @zqian
         }
 
         // Disconnect from db.
@@ -238,7 +237,7 @@ public class BayesBaseH {
          */
 
         long l2 = System.currentTimeMillis(); // @zqian: Measure structure learning time.
-        logger.info("\n*****************\nStructure Learning Time(ms): " + (l2 - l) + " ms.\n");
+        logger.fine("\n*****************\nStructure Learning Time(ms): " + (l2 - l) + " ms.\n");
     }
 
 
@@ -341,7 +340,7 @@ public class BayesBaseH {
 
         String NoTuples = "";
         for(String id : pvar_ids) {
-            logger.info("\nStarting Learning the BN Structure of pvar_ids: " + id + "\n");
+            logger.fine("\nStarting Learning the BN Structure of pvar_ids: " + id + "\n");
             Statement st = con3.createStatement();
             ResultSet rs = st.executeQuery("SELECT count(*) FROM `" + id.replace("`","") + "_counts`;"); // Optimize this query, too slow, Nov 13, zqian.
             while(rs.next()) {
@@ -376,7 +375,7 @@ public class BayesBaseH {
                 st2.close();
             }
 
-            logger.info("\nEnd for " + id + "\n");
+            logger.fine("\nEnd for " + id + "\n");
         }
 
         pvar_ids.clear();
@@ -395,7 +394,7 @@ public class BayesBaseH {
 
             String NoTuples = "";
             for(String id : rnode_ids) {
-                logger.info("\nStarting Learning the BN Structure of rnode_ids: " + id + "\n");
+                logger.fine("\nStarting Learning the BN Structure of rnode_ids: " + id + "\n");
                 Statement mapping_st = con2.createStatement();
                 Statement st = con3.createStatement();
                 ResultSet rnidMappingResult = mapping_st.executeQuery(
@@ -424,7 +423,7 @@ public class BayesBaseH {
                         !cont.equals("1")
                     );
 
-                    logger.info("The BN Structure Learning for rnode_id::" + id + "is done."); //@zqian Test
+                    logger.fine("The BN Structure Learning for rnode_id::" + id + "is done."); //@zqian Test
                     bif2(id); // import to db   @zqian
                 }
             }
@@ -561,7 +560,7 @@ public class BayesBaseH {
 
             rnode_ids.clear(); // Prepare for next loop.
 
-            logger.info(" Import is done for length = " + len + "."); // @zqian Test
+            logger.fine(" Import is done for length = " + len + "."); // @zqian Test
         }
     }
 
@@ -691,19 +690,19 @@ public class BayesBaseH {
     // Import to Entity_BayesNets.
     private static void bif1(String id) throws SQLException, IOException, ParsingException {
         // Import @zqian.
-        logger.info("Starting to Import the learned path into MySQL::**Entity_BayesNets**"); // @zqian Test
+        logger.fine("Starting to Import the learned path into MySQL::**Entity_BayesNets**"); // @zqian Test
         Statement st = con2.createStatement();
 
         BIFImport.Import(databaseName + "/" + File.separator + "xml" + File.separator + id.replace("`","") + ".xml", id, "Entity_BayesNets", con2);
-        logger.info("*** imported Entity_BayesNets " + id + " into database");
-        logger.info(" \n !!!!!!!!!Import is done for **Entity_BayesNets** \n"); // @zqian Test
+        logger.fine("*** imported Entity_BayesNets " + id + " into database");
+        logger.fine(" \n !!!!!!!!!Import is done for **Entity_BayesNets** \n"); // @zqian Test
         st.close();
     }
 
 
     // Import to Path_BayesNets // zqian@Oct 2nd 2013.
     private static void bif2(String id) throws SQLException, IOException, ParsingException {
-        logger.info(" Starting to Import the learned path into MySQL::**Path_BayesNets**"); // @zqian
+        logger.fine(" Starting to Import the learned path into MySQL::**Path_BayesNets**"); // @zqian
 
         Statement st = con2.createStatement();
 
@@ -713,9 +712,9 @@ public class BayesBaseH {
         // Delete the edges which is already forbidden in a lower level before inserting into the database.
         // Nov 25
         st.execute("DELETE FROM Path_BayesNets WHERE Rchain = '" + id + "' AND (child, parent) IN (SELECT child, parent FROM Path_Forbidden_Edges WHERE Rchain = '" + id + "');"); // Oct 2nd
-        logger.info("*** imported Path_BayesNets " + id + "into database");
+        logger.fine("*** imported Path_BayesNets " + id + "into database");
 
-        logger.info(" Import is done for **Path_BayesNets**"); // @zqian Test
+        logger.fine(" Import is done for **Path_BayesNets**"); // @zqian Test
         st.close();
     }
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CP.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CP.java
@@ -103,7 +103,7 @@ public class CP {
         generateCPTable(rchain, con1);
 
         long l2 = System.currentTimeMillis(); // @zqian : measure parameter learning time
-        logger.info("Parameter Learning Time(ms): " + (l2 - l) + " ms.\n");
+        logger.fine("Parameter Learning Time(ms): " + (l2 - l) + " ms.\n");
     }
 
     /**

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/KLD_generator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/KLD_generator.java
@@ -263,7 +263,7 @@ public class KLD_generator {
                     table_name
                 ) +
             ");";
-        logger.warning("bottleneck? query2:" + query2);
+        logger.fine("bottleneck? query2:" + query2);
         st.execute(query2);
 
         // Add all MULT by 1, Laplace.

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/LoggerConfig.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/LoggerConfig.java
@@ -92,7 +92,7 @@ public class LoggerConfig {
 
             builder.append(prefix);
             builder.append(record.getMessage());
-            builder.append("\n\r");
+            builder.append("\n");
 
             return builder.toString();
         }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/Sort_merge3.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/Sort_merge3.java
@@ -32,7 +32,7 @@ public class Sort_merge3 {
 
 
     public static void sort_merge(String table1, String table2, String table3, Connection conn) throws SQLException, IOException {
-        logger.info("\nGenerating false table by Subtraction using Sort_merge, cur_false_Table is: " + table3);
+        logger.fine("\nGenerating false table by Subtraction using Sort_merge, cur_false_Table is: " + table3);
 
         Statement st1 = (Statement) conn.createStatement();
         Statement st2 = (Statement) conn.createStatement();
@@ -69,7 +69,7 @@ public class Sort_merge3 {
 
             long time5 = System.currentTimeMillis();
 //            System.out.print("\t export csv file to sql: " + (time5 - time4));
-            logger.info("\ntotal time: " + (time5 - time1) + "\n");
+            logger.fine("\ntotal time: " + (time5 - time1) + "\n");
         } else { // Aug 18, 2014 zqian: Handle the extreme case when there's only `mult` column.
             logger.fine("\n \t Handle the extreme case when there's only `mult` column \n");
             st2.execute("DROP TABLE IF EXISTS " + table3 + ";");


### PR DESCRIPTION
- I have cleaned up the logging so that there are no more System.out.println() statements and
  instead we only use our FactorBase logger.
- I have removed many of the print statements since they don't really give us much useful
  information.  If we really need them, we can always put them back in at a later date.
- The current output for FactorBase when set to "info" level logging looks something like the following:
```
Start Program...
Runtime[Logger + Config Initialization]: 83ms.
Runtime[Creating Database Connection]: 3331ms.
Runtime[Creating Setup Database]: 1121ms.
Runtime[Creating CT Tables]: 2571ms.
Runtime[Running BayesBaseH]: 7320ms.
Runtime[Cleanup Database]: 65ms.
Runtime[Total]: 14491ms.
Program Done!
```
To me, this looks much cleaner and easier to pull out the runtime and its breakdown.