### PR TITLE
Fix lattice query

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/data/FunctorNodesInfo.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/data/FunctorNodesInfo.java
@@ -5,10 +5,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Class to hold all the relevant FunctorNode information for a given ID (PVar/RNode).
+ * Class to hold all the relevant FunctorNode information for a given ID (PVar/RNode/RChain).
  */
 public class FunctorNodesInfo {
     private String id;
+    private boolean isRChainID;
     private Map<String, FunctorNode> functorNodes;
     private boolean valuesAreDiscrete;
 
@@ -18,9 +19,11 @@ public class FunctorNodesInfo {
      *
      * @param id - the ID associated with the functor node information being stored.
      * @param valuesAreDiscrete - true if all the functor node states are discrete; otherwise false.
+     * @param isRChainID - true if the ID provided is for an RChain; otherwise false.
      */
-    public FunctorNodesInfo(String id, boolean valuesAreDiscrete) {
+    public FunctorNodesInfo(String id, boolean valuesAreDiscrete, boolean isRChainID) {
         this.id = id;
+        this.isRChainID = isRChainID;
         this.valuesAreDiscrete = valuesAreDiscrete;
         this.functorNodes = new LinkedHashMap<String, FunctorNode>();
     }
@@ -74,6 +77,16 @@ public class FunctorNodesInfo {
      */
     public boolean isDiscrete() {
         return this.valuesAreDiscrete;
+    }
+
+
+    /**
+     * Determine if the ID for the {@code FunctorNodesInfo} is for an RChain.
+     *
+     * @return true if the ID is for an RChain; otherwise false.
+     */
+    public boolean isRChainID() {
+        return this.isRChainID;
     }
 
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/LatticeGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/LatticeGenerator.java
@@ -128,7 +128,7 @@ public class LatticeGenerator {
         Map<String, FunctorNodesInfo> functorNodesInfos
     ) {
         String[] rnodeIDs = rchain.replace("),", ") ").split(" ");
-        FunctorNodesInfo rchainFunctorNodeInfo = new FunctorNodesInfo(rchain, true);
+        FunctorNodesInfo rchainFunctorNodeInfo = new FunctorNodesInfo(rchain, true, true);
 
         // for loop to merge all the functor node information into a single FunctorNodesInfo for the RChain.
         for (String rnodeID : rnodeIDs) {

--- a/code/factorbase/src/main/resources/scripts/latticegenerator_populate.sql
+++ b/code/factorbase/src/main/resources/scripts/latticegenerator_populate.sql
@@ -4,6 +4,7 @@
  */
 TRUNCATE lattice_membership;
 INSERT INTO lattice_membership
+    -- Get the "name"s and "member"s where the "name"s are unique to the local lattice.
     SELECT
         name,
         member
@@ -11,7 +12,25 @@ INSERT INTO lattice_membership
         @database@_setup.lattice_membership LMEM,
         LatticeRNodes LR
     WHERE
-        LMEM.member = LR.orig_rnid;
+        LMEM.member = LR.orig_rnid
+    AND
+        name
+    NOT IN (
+        -- Get the "name"s that belong to RNodes that are not in the local lattice.
+        SELECT
+            name
+        FROM
+            @database@_setup.lattice_membership
+        WHERE
+            member
+        NOT IN (
+            -- Get the RNodes for the local lattice.
+            SELECT
+                orig_rnid
+            FROM
+                LatticeRNodes
+        )
+    );
 
 
 TRUNCATE lattice_rel;


### PR DESCRIPTION
I noticed that the local lattices we were generating included RNodes that weren't a part of the FunctorSet so I've updated the query for generating the lattice_membership table to correctly exclude them.

Note: Only the last commit is new compared to the pull request here:
https://github.com/sfu-cl-lab/FactorBase/pull/153