### PR TITLE
Correct table names

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/data/FunctorNodesInfo.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/data/FunctorNodesInfo.java
@@ -9,6 +9,7 @@ import java.util.Map;
  */
 public class FunctorNodesInfo {
     private String id;
+    private String shortID;
     private boolean isRChainID;
     private Map<String, FunctorNode> functorNodes;
     private boolean valuesAreDiscrete;
@@ -23,6 +24,25 @@ public class FunctorNodesInfo {
      */
     public FunctorNodesInfo(String id, boolean valuesAreDiscrete, boolean isRChainID) {
         this.id = id;
+        this.shortID = null;
+        this.isRChainID = isRChainID;
+        this.valuesAreDiscrete = valuesAreDiscrete;
+        this.functorNodes = new LinkedHashMap<String, FunctorNode>();
+    }
+
+
+    /**
+     * Create a FunctorNodesInfo to store the functor node information for the given ID that has a short version of
+     * the ID.
+     *
+     * @param id - the ID associated with the functor node information being stored.
+     * @param shortID - the short version of the ID associated with the functor node information being stored.
+     * @param valuesAreDiscrete - true if all the functor node states are discrete; otherwise false.
+     * @param isRChainID - true if the ID provided is for an RChain; otherwise false.
+     */
+    public FunctorNodesInfo(String id, String shortID, boolean valuesAreDiscrete, boolean isRChainID) {
+        this.id = id;
+        this.shortID = shortID;
         this.isRChainID = isRChainID;
         this.valuesAreDiscrete = valuesAreDiscrete;
         this.functorNodes = new LinkedHashMap<String, FunctorNode>();
@@ -47,6 +67,17 @@ public class FunctorNodesInfo {
      */
     public String getID() {
         return this.id;
+    }
+
+
+    /**
+     * The short version of the ID associated with the stored functor nodes.
+     *
+     * @return the short version of the ID associated with the stored functor nodes or {@code null} if there is no
+     *         short version of the ID associated with the stored functor nodes.
+     */
+    public String getShortID() {
+        return this.shortID;
     }
 
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -399,8 +399,18 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
             // TODO: Figure out best way to reuse substituted file instead of recreating a new one each time.
             BayesBaseCT_SortMerge.buildCT();
 
+            String tableName = null;
+            String shortID = functorInfos.getShortID();
+            if (shortID != null) {
+                tableName = shortID + "_CT";
+            } else {
+                tableName = functorInfos.getID() + "_counts";
+            }
+
             PreparedStatement query = this.dbConnection.prepareStatement(
-                "SELECT * FROM " + dbInfo.getCTDatabaseName() + ".`" + functorInfos.getID() + "_counts` WHERE MULT > 0;"
+                "SELECT * " +
+                "FROM " + dbInfo.getCTDatabaseName() + ".`" + tableName + "` " +
+                "WHERE MULT > 0;"
             );
 
             DataExtractor dataextractor = new MySQLDataExtractor(query, dbInfo.getCountColumnName(), dbInfo.isDiscrete());

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/LatticeGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/LatticeGenerator.java
@@ -93,7 +93,9 @@ public class LatticeGenerator {
             Statement statement = dbConnection.createStatement();
             ResultSet results = statement.executeQuery(
                 "SELECT * " +
-                "FROM lattice_set;"
+                "FROM lattice_set " +
+                "JOIN lattice_mapping " +
+                "ON lattice_set.name = lattice_mapping.orig_rnid;"
             )
         ) {
             RelationshipLattice lattice = new RelationshipLattice();
@@ -101,6 +103,7 @@ public class LatticeGenerator {
             while(results.next()) {
                 FunctorNodesInfo rchainInfo = extractRChainFunctorNodeInfo(
                     results.getString("name"),
+                    results.getString("short_rnid"),
                     functorNodesInfos
                 );
 
@@ -119,16 +122,18 @@ public class LatticeGenerator {
      * Retrieve all the functor node information for the given RChain.
      *
      * @param rchain - the name of the RChain.
+     * @param shortRChain - the name of the RChain using short RNode IDs.
      * @param functorNodesInfos - {@code FunctorNodesInfo}s with the functor node information for all the RNodes in the
      *                            database that the RChain is from.
      * @return all the functor node information for the given RChain.
      */
     private static FunctorNodesInfo extractRChainFunctorNodeInfo(
         String rchain,
+        String shortRChain,
         Map<String, FunctorNodesInfo> functorNodesInfos
     ) {
         String[] rnodeIDs = rchain.replace("),", ") ").split(" ");
-        FunctorNodesInfo rchainFunctorNodeInfo = new FunctorNodesInfo(rchain, true, true);
+        FunctorNodesInfo rchainFunctorNodeInfo = new FunctorNodesInfo(rchain, shortRChain, true, true);
 
         // for loop to merge all the functor node information into a single FunctorNodesInfo for the RChain.
         for (String rnodeID : rnodeIDs) {


### PR DESCRIPTION
For PVariables we were able to use the ID field of the FunctorNodesInfo object to help generate the name of the generated "_counts" table; however, for RChains a new short ID field had to be added to the object, which could be used to help generate the name of the "_CT" table.

Note: Only the last commit is new compared to the pull request here:
https://github.com/sfu-cl-lab/FactorBase/pull/154