### PR TITLE
Scripts as stored procedures

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -116,6 +116,12 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
             );
             MySQLScriptRunner.runScript(
                 this.dbConnection,
+                Config.SCRIPTS_DIRECTORY + "latticegenerator_populate.sql",
+                this.baseDatabaseName,
+                "//"
+            );
+            MySQLScriptRunner.runScript(
+                this.dbConnection,
                 Config.SCRIPTS_DIRECTORY + "transfer_initialize.sql",
                 this.baseDatabaseName
             );
@@ -414,7 +420,6 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
             }
 
             // Generate CT tables.
-            // TODO: Figure out best way to reuse substituted file instead of recreating a new one each time.
             BayesBaseCT_SortMerge.buildCT();
 
             String tableName = null;

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -141,6 +141,12 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
                 this.baseDatabaseName,
                 "//"
             );
+            MySQLScriptRunner.runScript(
+                this.dbConnection,
+                Config.SCRIPTS_DIRECTORY + "metaqueries_RChain.sql",
+                this.baseDatabaseName,
+                "//"
+            );
         } catch (SQLException | IOException e) {
             throw new DataBaseException("An error occurred when attempting to setup the database for FactorBase.", e);
         }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -135,6 +135,12 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
                 Config.SCRIPTS_DIRECTORY + "metaqueries_initialize.sql",
                 this.baseDatabaseName
             );
+            MySQLScriptRunner.runScript(
+                this.dbConnection,
+                Config.SCRIPTS_DIRECTORY + "metaqueries_populate.sql",
+                this.baseDatabaseName,
+                "//"
+            );
         } catch (SQLException | IOException e) {
             throw new DataBaseException("An error occurred when attempting to setup the database for FactorBase.", e);
         }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -121,6 +121,12 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
             );
             MySQLScriptRunner.runScript(
                 this.dbConnection,
+                Config.SCRIPTS_DIRECTORY + "transfer_cascade.sql",
+                this.baseDatabaseName,
+                "//"
+            );
+            MySQLScriptRunner.runScript(
+                this.dbConnection,
                 Config.SCRIPTS_DIRECTORY + "modelmanager_initialize.sql",
                 this.baseDatabaseName
             );

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/LatticeGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/LatticeGenerator.java
@@ -13,9 +13,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
+
 import com.mysql.jdbc.Connection;
 
-import ca.sfu.cs.common.Configuration.Config;
 import ca.sfu.cs.factorbase.data.FunctorNodesInfo;
 import ca.sfu.cs.factorbase.util.MySQLScriptRunner;
 
@@ -43,10 +43,9 @@ public class LatticeGenerator {
         String databaseName
     ) throws SQLException, IOException {
         // Transfer all the local relationship lattice information from the global relationship lattice.
-        MySQLScriptRunner.runScript(
+        MySQLScriptRunner.callSP(
             dbConnection,
-            Config.SCRIPTS_DIRECTORY + "latticegenerator_populate.sql",
-            databaseName
+            "populateLattice"
         );
 
         try (

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseCT_SortMerge.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseCT_SortMerge.java
@@ -72,10 +72,9 @@ public class BayesBaseCT_SortMerge {
         con_CT = connectDB(databaseName_CT);
 
         //build _BN copy from _setup Nov 1st, 2013 Zqiancompute the subset given fid and it's parents
-        MySQLScriptRunner.runScript(
+        MySQLScriptRunner.callSP(
             con_BN,
-            Config.SCRIPTS_DIRECTORY + "transfer_cascade.sql",
-            databaseName_std
+            "cascadeFS"
         );
 
         //generate lattice tree

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseCT_SortMerge.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseCT_SortMerge.java
@@ -88,10 +88,9 @@ public class BayesBaseCT_SortMerge {
         if (cont.equals("1")) {
             throw new UnsupportedOperationException("Not Implemented Yet!");
         } else {
-            MySQLScriptRunner.runScript(
+            MySQLScriptRunner.callSP(
                 con_BN,
-                Config.SCRIPTS_DIRECTORY + "metaqueries_populate.sql",
-                databaseName_std
+                "populateMQ"
             );
         }
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseCT_SortMerge.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseCT_SortMerge.java
@@ -94,10 +94,9 @@ public class BayesBaseCT_SortMerge {
             );
         }
 
-        MySQLScriptRunner.runScript(
+        MySQLScriptRunner.callSP(
             con_BN,
-            Config.SCRIPTS_DIRECTORY + "metaqueries_RChain.sql",
-            databaseName_std
+            "populateMQRChain"
         );
 
         // building CT tables for Rchain

--- a/code/factorbase/src/main/resources/scripts/latticegenerator_populate.sql
+++ b/code/factorbase/src/main/resources/scripts/latticegenerator_populate.sql
@@ -2,6 +2,9 @@
  * Populate the local relationship lattice tables by extracting information from the global relationship lattice
  * tables.
  */
+CREATE PROCEDURE populateLattice()
+BEGIN
+
 TRUNCATE lattice_membership;
 INSERT INTO lattice_membership
     -- Get the "name"s and "member"s where the "name"s are unique to the local lattice.
@@ -74,3 +77,5 @@ INSERT IGNORE INTO lattice_mapping
         LMEM.member = LR.orig_rnid
     AND
         LMAP.orig_rnid = LMEM.name;
+
+END//

--- a/code/factorbase/src/main/resources/scripts/metaqueries_RChain.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_RChain.sql
@@ -1,7 +1,8 @@
-SET storage_engine=INNODB;
-
 /* May 16th, last step for _CT tables, preparing the colunmname_list */
 /* set up the join tables that represent the case where a relationship is false and its attributes are undefined */
+
+CREATE PROCEDURE populateMQRChain()
+BEGIN
 
 INSERT into MetaQueries
 SELECT DISTINCT
@@ -331,3 +332,5 @@ SELECT DISTINCT
     M.Entries 
 FROM lattice_rel, MetaQueries M
 WHERE lattice_rel.parent = 'EmptySet' AND M.Lattice_Point = lattice_rel.removed AND M.TableType = 'STAR' and M.ClauseType = 'SELECT';
+
+END//

--- a/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
@@ -7,8 +7,8 @@
  * RNodes_2Nodes
  * RNodes_pvars
  */
-
-SET storage_engine=INNODB;
+CREATE PROCEDURE populateMQ()
+BEGIN
 
 TRUNCATE MetaQueries;
 
@@ -333,3 +333,5 @@ INSERT INTO MetaQueries
         Lattice_Point = L.`member`
     AND
         M.TableType = 'COUNTS';
+
+END//

--- a/code/factorbase/src/main/resources/scripts/transfer_cascade.sql
+++ b/code/factorbase/src/main/resources/scripts/transfer_cascade.sql
@@ -1,5 +1,8 @@
 /* Cascade the information (based on the FunctorSet table) into the tables created by the transfer_initialize.sql script. */
 
+CREATE PROCEDURE cascadeFS()
+BEGIN
+
 TRUNCATE 1Nodes;
 INSERT INTO 1Nodes
     SELECT
@@ -203,3 +206,5 @@ INSERT INTO LatticeRNodes
         RNodes R
     WHERE
         LR.orig_rnid = R.rnid;
+
+END//


### PR DESCRIPTION
Since the buildCT() method is called many times with on-demand counting, it means that we are sending the script data many times as well as parsing the template script files many times (to replace the "@database@" with the input database name).  By moving the queries into a stored procedure and calling the stored procedure we avoid parsing the file multiple times and reduce network traffic.  Hopefully this helps speed up the buildCT() method a little bit for on-demand counting.