### PR TITLE
Cleanup setup

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CP.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CP.java
@@ -167,7 +167,16 @@ public class CP {
         );
 
         st.execute("drop table if exists NumAttributes;");
-        st.execute("create table NumAttributes as SELECT count(VALUE) as NumAtts, COLUMN_NAME FROM Attribute_Value group by COLUMN_NAME;");
+        st.execute(
+            "CREATE TABLE NumAttributes AS " +
+                "SELECT " +
+                    "COUNT(VALUE) AS NumAtts, " +
+                    "COLUMN_NAME " +
+                "FROM " +
+                    real_database + "_setup.Attribute_Value " +
+                "GROUP BY " +
+                    "COLUMN_NAME;"
+        );
 
         st.execute("drop table if exists RNodes_inFamily;");
         st.execute(

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CP.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CP.java
@@ -697,7 +697,12 @@ public class CP {
             st.execute("ALTER IGNORE TABLE `PVariables` ADD COLUMN `Tuples` BIGINT(20) NULL AFTER `index_number`;");
         }
         // Updating PVariables
-        ResultSet rs = st.executeQuery("SELECT table_name FROM EntityTables;");
+        ResultSet rs = st.executeQuery(
+            "SELECT " +
+                "table_name " +
+            "FROM " +
+                real_database + "_setup.EntityTables;"
+        );
         java.sql.Statement st1 = con1.createStatement();
         while(rs.next()) {
             String entity_table = rs.getString("table_name");

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CPGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CPGenerator.java
@@ -16,20 +16,37 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 public class CPGenerator {
-    public static void  Generator(String databaseName2, Connection con2) throws SQLException, IOException {
-        Statement st1 = con2.createStatement();
+    public static void  Generator(
+        String databaseName,
+        Connection con
+    ) throws SQLException, IOException {
+        try (
+            Statement rnodeStatement = con.createStatement();
+            Statement statement = con.createStatement();
+            ResultSet results = rnodeStatement.executeQuery("SELECT rnid FROM RNodes;")
+        ) {
+            // Adding possible values of Rnodes into Attribute_Value. // Jun 6.
+            while(results.next()) {
+                String rnid = results.getString("rnid");
+                statement.execute("SET SQL_SAFE_UPDATES = 0;");
 
-        // Adding possible values of Rnodes into Attribute_Value. // Jun 6.
-        ResultSet rs1 = st1.executeQuery("SELECT rnid FROM RNodes;");
-        while(rs1.next()) {
-            String rnid = rs1.getString("rnid");
-            Statement st2 = con2.createStatement();
-            st2.execute("SET SQL_SAFE_UPDATES = 0;");
-
-            // Adding boolean values for rnodes.
-            st2.execute("DELETE FROM  Attribute_Value WHERE column_name = '" + rnid + "';");
-            st2.execute("INSERT INTO Attribute_Value VALUES('" + rnid + "', 'T');"); // April 28, 2014, zqian.
-            st2.execute("INSERT INTO Attribute_Value VALUES('" + rnid + "', 'F');"); // Keep consistency with CT table.
+                // Adding boolean values for rnodes.
+                // TODO: Figure out if this DELETE query is actually necessary.
+                statement.execute(
+                    "DELETE FROM " +
+                        databaseName + "_setup.Attribute_Value " +
+                    "WHERE " +
+                        "column_name = '" + rnid + "';"
+                );
+                statement.execute(
+                    "INSERT INTO " + databaseName + "_setup.Attribute_Value " +
+                    "VALUES('" + rnid + "', 'T');"
+                );
+                statement.execute(
+                    "INSERT INTO " + databaseName + "_setup.Attribute_Value " +
+                    "VALUES('" + rnid + "', 'F');"
+                );
+            }
         }
     }
 }

--- a/code/factorbase/src/main/resources/scripts/transfer_cascade.sql
+++ b/code/factorbase/src/main/resources/scripts/transfer_cascade.sql
@@ -168,14 +168,6 @@ INSERT INTO EntityTables
         @database@_setup.EntityTables;
 
 
-TRUNCATE Attribute_Value;
-INSERT INTO Attribute_Value
-    SELECT
-        *
-    FROM
-        @database@_setup.Attribute_Value;
-
-
 TRUNCATE Expansions;
 INSERT INTO Expansions
     SELECT

--- a/code/factorbase/src/main/resources/scripts/transfer_cascade.sql
+++ b/code/factorbase/src/main/resources/scripts/transfer_cascade.sql
@@ -160,14 +160,6 @@ INSERT INTO PVariables
 /**
  * Transfer the rest.
  */
-TRUNCATE EntityTables;
-INSERT INTO EntityTables
-    SELECT
-        *
-    FROM
-        @database@_setup.EntityTables;
-
-
 TRUNCATE Expansions;
 INSERT INTO Expansions
     SELECT

--- a/code/factorbase/src/main/resources/scripts/transfer_initialize.sql
+++ b/code/factorbase/src/main/resources/scripts/transfer_initialize.sql
@@ -119,15 +119,6 @@ CREATE TABLE PVariables AS
         0;
 
 
-CREATE TABLE EntityTables AS
-    SELECT
-        *
-    FROM
-        @database@_setup.EntityTables
-    LIMIT
-        0;
-
-
 CREATE TABLE Expansions AS
     SELECT
         *

--- a/code/factorbase/src/main/resources/scripts/transfer_initialize.sql
+++ b/code/factorbase/src/main/resources/scripts/transfer_initialize.sql
@@ -128,15 +128,6 @@ CREATE TABLE EntityTables AS
         0;
 
 
-CREATE TABLE Attribute_Value AS
-    SELECT
-        *
-    FROM
-        @database@_setup.Attribute_Value
-    LIMIT
-        0;
-
-
 CREATE TABLE Expansions AS
     SELECT
         *

--- a/code/factorbase/src/main/resources/scripts/transfer_initialize.sql
+++ b/code/factorbase/src/main/resources/scripts/transfer_initialize.sql
@@ -8,10 +8,7 @@ CREATE TABLE 1Nodes AS
         N.pvid,
         N.main
     FROM
-        @database@_setup.1Nodes N,
-        @database@_setup.FunctorSet F
-    WHERE
-        N.1nid = F.fid
+        @database@_setup.1Nodes N
     LIMIT
         0;
 
@@ -25,10 +22,7 @@ CREATE TABLE 2Nodes AS
         N.TABLE_NAME,
         N.main
     FROM
-        @database@_setup.2Nodes N,
-        @database@_setup.FunctorSet F
-    WHERE
-        N.2nid = F.Fid
+        @database@_setup.2Nodes N
     LIMIT
         0;
 
@@ -39,10 +33,7 @@ CREATE TABLE RNodes_2Nodes AS
         N.2nid,
         N.main
     FROM
-        @database@_setup.RNodes_2Nodes N,
-        2Nodes F
-    WHERE
-        N.2nid = F.2nid
+        @database@_setup.RNodes_2Nodes N
     LIMIT
         0;
 
@@ -57,10 +48,7 @@ CREATE TABLE RNodes AS
         N.COLUMN_NAME2,
         N.main
     FROM
-        @database@_setup.RNodes N,
-        @database@_setup.FunctorSet F
-    WHERE
-        N.rnid = F.Fid
+        @database@_setup.RNodes N
     LIMIT
         0;
 
@@ -80,10 +68,7 @@ CREATE TABLE FNodes_pvars AS
         N.Fid,
         N.pvid
     FROM
-        @database@_setup.FNodes_pvars N,
-        FNodes F
-    WHERE
-        N.Fid = F.Fid
+        @database@_setup.FNodes_pvars N
     LIMIT
         0;
 
@@ -96,25 +81,19 @@ CREATE TABLE RNodes_pvars AS
         N.COLUMN_NAME,
         N.REFERENCED_COLUMN_NAME
     FROM
-        @database@_setup.RNodes_pvars N,
-        RNodes F
-    WHERE
-        N.rnid = F.rnid
+        @database@_setup.RNodes_pvars N
     LIMIT
         0;
 
 
 CREATE TABLE PVariables AS
-    SELECT DISTINCT
+    SELECT
         N.pvid,
         N.ID_COLUMN_NAME,
         N.TABLE_NAME,
         N.index_number
     FROM
-        @database@_setup.PVariables N,
-        FNodes_pvars F
-    WHERE
-        F.pvid = N.pvid
+        @database@_setup.PVariables N
     LIMIT
         0;
 

--- a/travis-resources/expected-output/mysql-extraction.txt
+++ b/travis-resources/expected-output/mysql-extraction.txt
@@ -36,43 +36,6 @@ capability(prof0,student0)	salary(prof0,student0)	3
 ChildNode	2node	NumAtts
 diff(course0)	grade(course0,student0)	4
 sat(course0,student0)	grade(course0,student0)	4
-Table: Attribute_Value
-capability	1
-capability	2
-capability	3
-capability	4
-capability	5
-COLUMN_NAME	VALUE
-diff	1
-diff	2
-grade	1
-grade	2
-grade	3
-grade	4
-intelligence	1
-intelligence	2
-intelligence	3
-popularity	1
-popularity	2
-ranking	1
-ranking	2
-ranking	3
-ranking	4
-ranking	5
-RA(prof0,student0)	F
-RA(prof0,student0)	T
-rating	1
-rating	2
-registration(course0,student0)	F
-registration(course0,student0)	T
-salary	high
-salary	low
-salary	med
-sat	1
-sat	2
-sat	3
-teachingability	2
-teachingability	3
 Table: ChildPars
 1	diff(course0)
 1	popularity(prof0)
@@ -1919,8 +1882,12 @@ ranking	2
 ranking	3
 ranking	4
 ranking	5
+RA(prof0,student0)	F
+RA(prof0,student0)	T
 rating	1
 rating	2
+registration(course0,student0)	F
+registration(course0,student0)	T
 salary	high
 salary	low
 salary	med

--- a/travis-resources/expected-output/mysql-extraction.txt
+++ b/travis-resources/expected-output/mysql-extraction.txt
@@ -51,11 +51,6 @@ Table: ChildPars
 4	ranking(student0)
 NumPars	ChildNode
 Table: ContextEdges
-Table: EntityTables
-course	course_id
-prof	prof_id
-student	student_id
-TABLE_NAME	COLUMN_NAME
 Table: Entity_BN_nodes
 course0	diff(course0)
 course0	rating(course0)


### PR DESCRIPTION
I'm still in the process of trying to streamline the transfer code, but here is what I have so far.  I have managed to stop transferring the data for the tables Attribute_Value and EntityTables from "_setup" to "_BN".  This change seems to have made us about 100ms faster per localscore call for on-demand counting (using unielwin).