### PR TITLE
Removed unnecessary "ORDER BY" in metaqueries_populate.sql.

### DIFF
--- a/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
@@ -286,10 +286,7 @@ INSERT INTO MetaQueries
     WHERE
         RN.rnid = L.orig_rnid
     AND
-        N.2nid = RN.2nid
-    ORDER BY
-        RN.rnid,
-        COLUMN_NAME;
+        N.2nid = RN.2nid;
 
 
 /**


### PR DESCRIPTION
- The "ORDER BY" clause in the metaqueries_populate.sql script is
  unnecessary and slows down on-demand counting, so it has been
  removed.