### PR TITLE
Only use the score cache in GesCT.java for caching the family scores.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/search/BDeuScore.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/search/BDeuScore.java
@@ -1,10 +1,7 @@
 package ca.sfu.cs.factorbase.search;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import ca.sfu.cs.factorbase.data.ContingencyTable;
@@ -21,7 +18,6 @@ public class BDeuScore implements DiscreteLocalScore {
     private ContingencyTableGenerator contingencyTableGenerator;
     private double samplePrior;
     private double structurePrior;
-    private Map<Integer, Double> cache = new HashMap<Integer, Double>();
 
 
     /**
@@ -42,11 +38,6 @@ public class BDeuScore implements DiscreteLocalScore {
     public double localScore(String child, Set<String> parents) {
         int childColumnIndex = this.contingencyTableGenerator.getColumnIndex(child);
         int[] parentColumnIndices = this.contingencyTableGenerator.getColumnIndices(parents);
-        int cacheKey = Objects.hash(childColumnIndex, parentColumnIndices);
-
-        if (this.cache.containsKey(cacheKey)) {
-            return this.cache.get(cacheKey);
-        }
 
         // Number of child states.
         int r = this.contingencyTableGenerator.getNumberOfStates(childColumnIndex);
@@ -77,8 +68,6 @@ public class BDeuScore implements DiscreteLocalScore {
 
         score = score.add(new BigDecimal(q * ProbUtils.lngamma(this.samplePrior / q)));
         score = score.subtract(new BigDecimal((r * q) * ProbUtils.lngamma(this.samplePrior / (r * q))));
-
-        this.cache.put(cacheKey, score.doubleValue());
 
         return score.doubleValue();
     }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/search/BDeuScoreOnDemand.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/search/BDeuScoreOnDemand.java
@@ -2,10 +2,7 @@ package ca.sfu.cs.factorbase.search;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import ca.sfu.cs.factorbase.data.ContingencyTable;
@@ -26,7 +23,6 @@ public class BDeuScoreOnDemand implements DiscreteLocalScore {
     private FunctorNodesInfo functorInfos;
     private double samplePrior;
     private double structurePrior;
-    private Map<Integer, Double> cache = new HashMap<Integer, Double>();
 
 
     /**
@@ -52,12 +48,6 @@ public class BDeuScoreOnDemand implements DiscreteLocalScore {
 
     @Override
     public double localScore(String child, Set<String> parents) throws ScoringException {
-        int cacheKey = Objects.hash(child, parents);
-
-        if (this.cache.containsKey(cacheKey)) {
-            return this.cache.get(cacheKey);
-        }
-
         // Number of child states.
         int r = this.functorInfos.getNumberOfStates(child);
 
@@ -89,8 +79,6 @@ public class BDeuScoreOnDemand implements DiscreteLocalScore {
 
             score = score.add(new BigDecimal(q * ProbUtils.lngamma(this.samplePrior / q)));
             score = score.subtract(new BigDecimal((r * q) * ProbUtils.lngamma(this.samplePrior / (r * q))));
-
-            this.cache.put(cacheKey, score.doubleValue());
 
             return score.doubleValue();
         } catch (DataBaseException e) {

--- a/code/factorbase/src/main/java/edu/cmu/tetrad/search/GesCT.java
+++ b/code/factorbase/src/main/java/edu/cmu/tetrad/search/GesCT.java
@@ -964,12 +964,15 @@ public class GesCT {
         Graph dag = SearchGraphUtils.dagFromPattern(graph);
         double score = 0.;
 
-        for (Node y : dag.getNodes()) {
-            Set<Node> parents = new HashSet<Node>(dag.getParents(y));
+        for (Node child : dag.getNodes()) {
+            Set<Node> parents = new HashSet<Node>(dag.getParents(child));
             Set<String> parentNames = parents.stream().map(node -> node.getName()).collect(Collectors.toSet());
+            String childName = child.getName();
 
             if (this.isDiscrete()) {
-                score += localDiscreteScore(y.getName(), parentNames);
+                double cachedScore = localDiscreteScore(childName, parentNames);
+                scoreHash.get(child).put(parents, cachedScore);
+                score += cachedScore;
             } else {
                 throw new UnsupportedOperationException("Not Implemented Yet!");
             }
@@ -986,7 +989,8 @@ public class GesCT {
     }
 
     private Double computeScore(Node child, Set<Node> parents) throws ScoringException {
-        Double score = scoreHash.get(child).get(parents);
+        Map<Set<Node>, Double> childScoreHash = scoreHash.get(child);
+        Double score = childScoreHash.get(parents);
 
         if (score == null) {
             Set<String> parentNames = parents.stream().map(node -> node.getName()).collect(Collectors.toSet());
@@ -997,7 +1001,7 @@ public class GesCT {
                 throw new UnsupportedOperationException("Not Implemented Yet!");
             }
 
-            scoreHash.get(child).put(parents, score);
+            childScoreHash.put(parents, score);
         }
 
         return score;


### PR DESCRIPTION
- Removed the score caches in BDeuScore.java and
  BDeuScoreOnDemand.java.  Removed any new unused imports as a result
  of this change.
- Updated the scoreGraph() method in GesCT.java to cache the scores
  computed for the initial families in the graph.
- Adjusted the logic in the computeScore() method of GesCT.java so
  that we only compute the hash for the child node once per call of
  the method.

Note: It's probably best to have the score cache in GesCT so that
      each score implementation doesn't need to re-implement its
      own cache.

For unielwin, this reduced the number of local_score calls from 299 to 267, which is ~10%.