### PR TITLE
Removed FID check when creating an index during smoothing.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/KLD_generator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/KLD_generator.java
@@ -236,11 +236,9 @@ public class KLD_generator {
         }
 
         ArrayList<String> indexlist2 = new ArrayList<String>(indexlist1);
-        // Delete MULT, FID.
+        // Delete MULT and child.
         indexlist2.remove(0);
-        if (indexlist2.get(0).equalsIgnoreCase("FID")) {
-            indexlist2.remove(0);
-        }
+        indexlist2.remove(0);
 
         // Create clauses to add those indexes.
         // index1: MULT, current node and its parents.


### PR DESCRIPTION
- Removed the check that the item in the index list is "FID"
  before removing it from the list.  As far as I can tell, we intended
  to rename the column from the child name to "FID", but it looks like
  it was never done so removing this check.