### PR TITLE
Corrected and improved the query for retrieving the PVariable functor nodes.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/FactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/FactorBaseDataBase.java
@@ -73,9 +73,9 @@ public interface FactorBaseDataBase {
 
 
     /**
-     * Retrieve the functor node information for all the PVariables.
+     * Retrieve the functor node information for all the main PVariables.
      *
-     * @return Information for all the functor nodes of each PVariable in the database.
+     * @return Information for all the functor nodes of each main PVariable in the database.
      * @throws DataBaseException if an error occurs when attempting to retrieve the information.
      */
     List<FunctorNodesInfo> getPVariablesFunctorNodeInfo() throws DataBaseException;

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -248,7 +248,9 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
                 setupDatabaseName + ".1Nodes N, " +
                 setupDatabaseName + ".Attribute_Value A " +
             "WHERE P.pvid = N.pvid " +
-            "AND N.COLUMN_NAME = A.COLUMN_NAME";
+            "AND N.COLUMN_NAME = A.COLUMN_NAME " +
+            "AND index_number = 0 " +
+            "ORDER BY pvid, 1nid";
 
         List<FunctorNodesInfo> functorNodesInfos = new ArrayList<FunctorNodesInfo>();
         String previousPVarID = null;


### PR DESCRIPTION
- The getPVariablesFunctorNodeInfo() method is supposed to return the
  main PVariables and not all of them so the query in the
  getPVariablesFunctorNodeInfo() method in MySQLFactorBaseDataBase.java
  was updated to include a restriction based on the index_number column
  value.
- Updated the documentation for the getPVariablesFunctorNodeInfo()
  method in FactorBaseDataBase.java to reflect this correction.
- Added an "ORDER BY" to the query for retrieving the PVariable functor
  nodes so that we are guaranteed that we extract the PVariable functor
  node information correctly.