### PR TITLE
Removed the index from the "_star" tables.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -434,22 +434,13 @@ public class CountsManager {
                 // starting to create _flase table : part1
                 String cur_false_Table = removedShort + len + "_" + fc + "_false";
 
-                // Create false table.
+                // Computing the false table as the MULT difference between the matching rows of the star and flat tables.
+                // This is a big join!
                 Sort_merge3.sort_merge(
                     cur_star_Table,
                     cur_flat_Table,
                     cur_false_Table,
                     con_CT
-                );
-
-                 // a separate procedure for computing the false table as the mult difference between star and flat
-                 // trying to optimize this big join
-
-                // Add covering index.
-                addCoveringIndex(
-                    con_CT,
-                    databaseName_CT,
-                    cur_false_Table
                 );
 
                 long l5 = System.currentTimeMillis(); 
@@ -896,13 +887,6 @@ public class CountsManager {
                 shortRchain + "_flat",
                 falseTableName,
                 con_CT
-            );
-
-            // Add covering index.
-            addCoveringIndex(
-                con_CT,
-                databaseName_CT,
-                falseTableName
             );
 
             String countsTableName = shortRchain + "_counts";

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -396,13 +396,6 @@ public class CountsManager {
                 logger.fine("\n create star String : " + createStarString );
                 st3.execute(createStarString);      //create star table     
 
-                // Add covering index.
-                addCoveringIndex(
-                    con_CT,
-                    databaseName_CT,
-                    cur_star_Table
-                );
-
                 long l3 = System.currentTimeMillis(); 
                 logger.fine("Building Time(ms) for "+cur_star_Table+ " : "+(l3-l2)+" ms.\n");
                 //staring to create the _flat table
@@ -867,13 +860,6 @@ public class CountsManager {
             String createString = "CREATE TABLE `" + starTableName + "` AS " + queryString;
             logger.fine("\n create String : " + createString );
             st3.execute(createString);
-
-            // Add covering index.
-            addCoveringIndex(
-                con_CT,
-                databaseName_CT,
-                starTableName
-            );
 
             //  close statements
             st2.close();


### PR DESCRIPTION
- The "_star" tables are just used to help produce the "_false" tables
  and it was noticed that a full table scan was done when using the
  "_star" tables, making the index pointless and just a waste of time
  to generate so they have been removed.