### PR TITLE
Removed the index from the "_CT" and "_counts" tables.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -576,13 +576,6 @@ public class CountsManager {
             logger.fine("Create String: " + createString);
             st3.execute(createString);
 
-            // Add covering index.
-            addCoveringIndex(
-                con_CT,
-                databaseName_CT,
-                countsTableName
-            );
-
             //  close statements
             st2.close();
             st3.close();
@@ -726,13 +719,6 @@ public class CountsManager {
         st3.execute("SET tmp_table_size = " + dbTemporaryTableSize + ";");
         st3.executeQuery("SET max_heap_table_size = " + dbTemporaryTableSize + ";");
         st3.execute(createString);
-
-        // Add covering index.
-        addCoveringIndex(
-            dbConnection,
-            databaseName_CT,
-            countsTableName
-        );
 
         // Close statements.
         st2.close();

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -482,13 +482,6 @@ public class CountsManager {
                 st3.execute("CREATE TABLE `" + Next_CT_Table + "` AS " + QueryStringCT);
                 rs1.previous();
 
-                // Add covering index.
-                addCoveringIndex(
-                    con_CT,
-                    databaseName_CT,
-                    Next_CT_Table
-                );
-
                 fc++;   
 
                 //  close statements
@@ -918,13 +911,6 @@ public class CountsManager {
 
             logger.fine("\n create CT table String : " + createCTString );
             st3.execute(createCTString);
-
-            // Add covering index.
-            addCoveringIndex(
-                con_CT,
-                databaseName_CT,
-                ctTableName
-            );
 
             //  close statements
             st2.close();


### PR DESCRIPTION
- The "_CT" tables are always read in completely to get the count
  information, making the index pointless and just a waste of time to
  generate so they have been removed.

With these changes, UW has gone down to a bit over 4 minutes when using ondemand counting without projection.

3 baseline run times:
```
real    5m35.177s
user    0m17.352s
sys     0m3.848s

real    5m30.970s
user    0m17.436s
sys     0m3.968s

real    5m21.759s
user    0m18.444s
sys     0m4.372s
```
3 run times with the changes in this pull request:
```
real    4m23.238s
user    0m18.244s
sys     0m4.268s

real    4m18.664s
user    0m19.280s
sys     0m4.228s

real    4m16.502s
user    0m18.460s
sys     0m3.984s
```

I tried doing the same for the "_counts" tables and got this for 3 runs:
```
real    4m28.482s
user    0m18.040s
sys     0m3.456s

real    4m4.780s
user    0m17.784s
sys     0m3.408s

real    3m56.634s
user    0m16.520s
sys     0m3.796s
```