### PR TITLE
Cleanup metaqueries

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/LatticeGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/LatticeGenerator.java
@@ -165,9 +165,6 @@ public class LatticeGenerator {
     private static int init(Connection dbConnection, Collection<String> firstSets) throws SQLException {
         int maxNumberOfMembers = firstSets.size();
         Statement st = dbConnection.createStatement();
-        st.execute("TRUNCATE lattice_rel;");
-        st.execute("TRUNCATE lattice_membership;");
-        st.execute("TRUNCATE lattice_set;");
 
         for(String set : firstSets) {
             st.execute("INSERT INTO lattice_set (name, length) VALUES ('" + set + "', 1);");

--- a/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
@@ -281,7 +281,7 @@ INSERT INTO MetaQueries
  * proper rchains only.
  */
 INSERT INTO MetaQueries
-    SELECT
+    SELECT DISTINCT
         L.name AS Lattice_Point,
         'Counts' AS TableType,
         M.ClauseType,

--- a/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
@@ -24,7 +24,7 @@ CREATE TABLE MetaQueries (
 --- map Pvariables to entity tables ---
 
 INSERT INTO MetaQueries
-    SELECT DISTINCT
+    SELECT
         pvid AS Lattice_Point,
         'Counts' AS TableType,
         'FROM' AS ClauseType,
@@ -43,7 +43,7 @@ INSERT INTO MetaQueries
 /* Pvariable SELECT list */
 /* Contains 1nodes with renaming, and mult for aggregating, and id columns in case these are selected in the Expansions table. */
 INSERT INTO MetaQueries
-    SELECT DISTINCT
+    SELECT
         pvid AS Lattice_Point,
         'Counts' AS TableType,
         'SELECT' AS ClauseType,
@@ -55,13 +55,13 @@ INSERT INTO MetaQueries
 
 /* For each pvariable, find the SELECT list for the associated attributes = 1Nodes. */
 INSERT INTO MetaQueries
-    SELECT DISTINCT
-        P.pvid AS Lattice_Point,
+    SELECT
+        N.pvid AS Lattice_Point,
         'Counts' AS TableType,
         'SELECT' AS ClauseType,
         '1node' AS EntryType,
         CONCAT(
-            P.pvid,
+            N.pvid,
             '.',
             N.COLUMN_NAME,
             ' AS `',
@@ -69,10 +69,7 @@ INSERT INTO MetaQueries
             '`'
         ) AS Entries
     FROM
-        1Nodes N,
-        PVariables P
-    WHERE
-        N.pvid = P.pvid;
+        1Nodes N;
 
 
 /* For each pvariable in expansion, find the primary column and add it to the SELECT list. */
@@ -94,8 +91,8 @@ INSERT INTO MetaQueries
 /* Pvariable GROUPBY list. */
 /* Contains 1nodes without renaming. */
 INSERT INTO MetaQueries
-   SELECT DISTINCT
-       P.pvid AS Lattice_Point,
+   SELECT
+       N.pvid AS Lattice_Point,
        'Counts' AS TableType,
        'GROUPBY' AS ClauseType,
        '1node' AS EntryType,
@@ -105,10 +102,7 @@ INSERT INTO MetaQueries
             '`'
         ) AS Entries
     FROM
-        1Nodes N,
-        PVariables P
-    WHERE
-        N.pvid = P.pvid;
+        1Nodes N;
 
 
 /* Add id columns for expansions without renaming. */
@@ -142,8 +136,8 @@ INSERT INTO MetaQueries
 /* Now we make data join tables for each relationship functor node. */
 /* The FROM list for the relationship functor contains the relationship table. */
 INSERT INTO MetaQueries
-    SELECT DISTINCT
-        orig_rnid AS Lattice_Point,
+    SELECT
+        rnid AS Lattice_Point,
         'Counts' AS TableType,
         'FROM' AS ClauseType,
         'rtable' AS EntryType,
@@ -155,9 +149,7 @@ INSERT INTO MetaQueries
             '`'
         ) AS Entries
     FROM
-        RNodes R, LatticeRNodes L
-    WHERE
-        R.rnid = L.orig_rnid;
+        RNodes R;
 
 
 /**
@@ -165,8 +157,8 @@ INSERT INTO MetaQueries
  * the rnid.  This simulates the case where all the relationships are true.
  */
 INSERT INTO MetaQueries
-    SELECT DISTINCT
-        orig_rnid AS Lattice_Point,
+    SELECT
+        rnid AS Lattice_Point,
         'Counts' AS TableType,
         'SELECT' AS ClauseType,
         'rtable' AS EntryType,
@@ -176,10 +168,7 @@ INSERT INTO MetaQueries
             '`'
         ) AS Entries
     FROM
-        RNodes R,
-        LatticeRNodes L
-    WHERE
-        R.rnid = L.orig_rnid;
+        RNodes R;
 
 
 /**
@@ -187,8 +176,8 @@ INSERT INTO MetaQueries
  * table to the ids in the population entity tables.
  */
 INSERT INTO MetaQueries
-    SELECT DISTINCT
-        orig_rnid AS Lattice_Point,
+    SELECT
+        rnid AS Lattice_Point,
         'Counts' AS TableType,
         'WHERE' AS ClauseType,
         'rtable' AS EntryType,
@@ -203,10 +192,7 @@ INSERT INTO MetaQueries
             REFERENCED_COLUMN_NAME
         ) AS Entries
     FROM
-        RNodes_pvars R,
-        LatticeRNodes L
-    WHERE
-        R.rnid = L.orig_rnid;
+        RNodes_pvars R;
 
 
 /**
@@ -215,14 +201,14 @@ INSERT INTO MetaQueries
  * 2) The 2nodes of the relationship variable.
  */
 INSERT INTO MetaQueries
-    SELECT DISTINCT
-        orig_rnid AS Lattice_Point,
+    SELECT
+        rnid AS Lattice_Point,
         'Counts' AS TableType,
         'SELECT' AS ClauseType,
         '2nid' AS EntryType,
         CONCAT(
             '`',
-            L.orig_rnid,
+            rnid,
             '`.',
             COLUMN_NAME,
             ' AS `',
@@ -230,12 +216,9 @@ INSERT INTO MetaQueries
             '`'
         ) AS Entries
     FROM
-        LatticeRNodes L,
         RNodes_2Nodes RN,
         2Nodes N
     WHERE
-        RN.rnid = L.orig_rnid
-    AND
         N.2nid = RN.2nid;
 
 
@@ -258,8 +241,8 @@ INSERT INTO MetaQueries
 
 
 INSERT INTO MetaQueries
-    SELECT DISTINCT
-        orig_rnid AS Lattice_Point,
+    SELECT
+        rnid AS Lattice_Point,
         'Counts' AS TableType,
         'GROUPBY' AS ClauseType,
         '2nid' AS EntryType,
@@ -269,12 +252,9 @@ INSERT INTO MetaQueries
             '`'
         ) AS Entries
     FROM
-        LatticeRNodes L,
         RNodes_2Nodes RN,
         2Nodes N
     WHERE
-        RN.rnid = L.orig_rnid
-    AND
         N.2nid = RN.2nid;
 
 
@@ -284,18 +264,15 @@ INSERT INTO MetaQueries
  */
 INSERT INTO MetaQueries
     SELECT DISTINCT
-        orig_rnid AS Lattice_Point,
+        rnid AS Lattice_Point,
         TableType,
         ClauseType,
         EntryType,
         Entries
     FROM
-        LatticeRNodes L,
         RNodes_pvars R,
         MetaQueries M
     WHERE
-        L.orig_rnid = R.rnid
-    AND
         M.Lattice_Point = R.pvid;
 
 

--- a/code/factorbase/src/main/resources/scripts/transfer_cascade.sql
+++ b/code/factorbase/src/main/resources/scripts/transfer_cascade.sql
@@ -93,7 +93,7 @@ CREATE TABLE FNodes AS
     FROM
         1Nodes
 
-    UNION DISTINCT
+    UNION ALL
 
     SELECT
         2nid AS Fid,
@@ -103,7 +103,7 @@ CREATE TABLE FNodes AS
     FROM
         2Nodes
 
-    UNION DISTINCT
+    UNION ALL
 
     SELECT
         rnid AS Fid,

--- a/travis-resources/expected-output/mysql-extraction.txt
+++ b/travis-resources/expected-output/mysql-extraction.txt
@@ -220,12 +220,9 @@ RA(prof0,student0),registration(course0,student0)	Counts	FROM	rtable	unielwin.re
 RA(prof0,student0),registration(course0,student0)	Counts	FROM	table	unielwin.course AS course0
 RA(prof0,student0),registration(course0,student0)	Counts	FROM	table	unielwin.prof AS prof0
 RA(prof0,student0),registration(course0,student0)	Counts	FROM	table	unielwin.student AS student0
-RA(prof0,student0),registration(course0,student0)	Counts	FROM	table	unielwin.student AS student0
 RA(prof0,student0),registration(course0,student0)	Counts	GROUPBY	1node	`diff(course0)`
 RA(prof0,student0),registration(course0,student0)	Counts	GROUPBY	1node	`intelligence(student0)`
-RA(prof0,student0),registration(course0,student0)	Counts	GROUPBY	1node	`intelligence(student0)`
 RA(prof0,student0),registration(course0,student0)	Counts	GROUPBY	1node	`popularity(prof0)`
-RA(prof0,student0),registration(course0,student0)	Counts	GROUPBY	1node	`ranking(student0)`
 RA(prof0,student0),registration(course0,student0)	Counts	GROUPBY	1node	`ranking(student0)`
 RA(prof0,student0),registration(course0,student0)	Counts	GROUPBY	1node	`rating(course0)`
 RA(prof0,student0),registration(course0,student0)	Counts	GROUPBY	1node	`teachingability(prof0)`
@@ -240,14 +237,11 @@ RA(prof0,student0),registration(course0,student0)	Counts	SELECT	1node	course0.ra
 RA(prof0,student0),registration(course0,student0)	Counts	SELECT	1node	prof0.popularity AS `popularity(prof0)`
 RA(prof0,student0),registration(course0,student0)	Counts	SELECT	1node	prof0.teachingability AS `teachingability(prof0)`
 RA(prof0,student0),registration(course0,student0)	Counts	SELECT	1node	student0.intelligence AS `intelligence(student0)`
-RA(prof0,student0),registration(course0,student0)	Counts	SELECT	1node	student0.intelligence AS `intelligence(student0)`
-RA(prof0,student0),registration(course0,student0)	Counts	SELECT	1node	student0.ranking AS `ranking(student0)`
 RA(prof0,student0),registration(course0,student0)	Counts	SELECT	1node	student0.ranking AS `ranking(student0)`
 RA(prof0,student0),registration(course0,student0)	Counts	SELECT	2nid	`RA(prof0,student0)`.capability AS `capability(prof0,student0)`
 RA(prof0,student0),registration(course0,student0)	Counts	SELECT	2nid	`RA(prof0,student0)`.salary AS `salary(prof0,student0)`
 RA(prof0,student0),registration(course0,student0)	Counts	SELECT	2nid	`registration(course0,student0)`.grade AS `grade(course0,student0)`
 RA(prof0,student0),registration(course0,student0)	Counts	SELECT	2nid	`registration(course0,student0)`.sat AS `sat(course0,student0)`
-RA(prof0,student0),registration(course0,student0)	Counts	SELECT	aggregate	COUNT(*) AS "MULT"
 RA(prof0,student0),registration(course0,student0)	Counts	SELECT	aggregate	COUNT(*) AS "MULT"
 RA(prof0,student0),registration(course0,student0)	Counts	SELECT	rtable	"T" AS `RA(prof0,student0)`
 RA(prof0,student0),registration(course0,student0)	Counts	SELECT	rtable	"T" AS `registration(course0,student0)`


### PR DESCRIPTION
- I noticed duplicate rows in the MetaQueries table and thought that was odd so I looked into it further.  It turns out one of the queries that inserts into the MetaQueries table needed a "DISTINCT" applied.
- Since I was looking at the scripts I decided to see if I could clean up some of the other related queries.  It turns out we were using the "DISTINCT" keyword (which causes us to use tmp tables) when it didn't seem necessary and we were joining with tables, but the tables being joined with didn't seem to have its columns used or restrict the result set (which causes us to use an extra join buffer).
- Some "UNION DISTINCT" were changed to "UNION ALL" since each of the results being merged together should be unique as far as I can tell.
- I also removed unnecessary "TRUNCATE" calls in LatticeGenerator.  The code is always run on a fresh copy of the FactorBase databases so there is no need to try and clear the tables.