### PR TITLE
Metadata memory tables

### DIFF
--- a/code/factorbase/src/main/resources/scripts/latticegenerator_populate.sql
+++ b/code/factorbase/src/main/resources/scripts/latticegenerator_populate.sql
@@ -6,7 +6,7 @@ CREATE PROCEDURE populateLattice()
 BEGIN
 
 DROP TABLE IF EXISTS lattice_membership;
-CREATE TABLE lattice_membership AS
+CREATE TABLE lattice_membership ENGINE = MEMORY AS
     -- Get the "name"s and "member"s where the "name"s are unique to the local lattice.
     SELECT
         name,
@@ -37,7 +37,7 @@ CREATE TABLE lattice_membership AS
 
 
 DROP TABLE IF EXISTS lattice_rel;
-CREATE TABLE lattice_rel AS
+CREATE TABLE lattice_rel ENGINE = MEMORY AS
     SELECT
         parent,
         child,
@@ -50,7 +50,7 @@ CREATE TABLE lattice_rel AS
 
 
 DROP TABLE IF EXISTS lattice_set;
-CREATE TABLE lattice_set AS
+CREATE TABLE lattice_set ENGINE = MEMORY AS
     SELECT
         LS.name,
         length
@@ -67,7 +67,7 @@ CREATE TABLE lattice_set AS
 
 
 DROP TABLE IF EXISTS lattice_mapping;
-CREATE TABLE lattice_mapping AS
+CREATE TABLE lattice_mapping ENGINE = MEMORY AS
     SELECT
         LMAP.orig_rnid,
         LMAP.short_rnid

--- a/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
@@ -17,7 +17,7 @@ CREATE TABLE MetaQueries (
     ClauseType varchar(10), /* FROM, WHERE, SELECT, GROUPBY */
     EntryType varchar(100), /* e.g. 1node, aggregate like count */
     Entries varchar(150)
-) ENGINE = INNODB;
+) ENGINE = MEMORY;
 
 /* metaqueries for population variables */
 

--- a/code/factorbase/src/main/resources/scripts/transfer_cascade.sql
+++ b/code/factorbase/src/main/resources/scripts/transfer_cascade.sql
@@ -4,7 +4,7 @@ CREATE PROCEDURE cascadeFS()
 BEGIN
 
 DROP TABLE IF EXISTS 1Nodes;
-CREATE TABLE 1Nodes AS
+CREATE TABLE 1Nodes ENGINE = MEMORY AS
     SELECT
         N.1nid,
         N.COLUMN_NAME,
@@ -18,7 +18,7 @@ CREATE TABLE 1Nodes AS
 
 
 DROP TABLE IF EXISTS 2Nodes;
-CREATE TABLE 2Nodes AS
+CREATE TABLE 2Nodes ENGINE = MEMORY AS
     SELECT
         N.2nid,
         N.COLUMN_NAME,
@@ -35,7 +35,7 @@ CREATE TABLE 2Nodes AS
 
 /* Map the 2nodes to rnodes for the given 2Nodes in the functor set. */
 DROP TABLE IF EXISTS RNodes_2Nodes;
-CREATE TABLE RNodes_2Nodes AS
+CREATE TABLE RNodes_2Nodes ENGINE = MEMORY AS
     SELECT
         N.rnid,
         N.2nid,
@@ -49,7 +49,7 @@ CREATE TABLE RNodes_2Nodes AS
 
 /* Copy the rnodes for the functor set. */
 DROP TABLE IF EXISTS RNodes;
-CREATE TABLE RNodes AS
+CREATE TABLE RNodes ENGINE = MEMORY AS
     SELECT
         N.rnid,
         N.TABLE_NAME,
@@ -84,7 +84,7 @@ CREATE TABLE RNodes AS
 
 /* Make comprehensive table for all functor nodes but restricted to the functor set. */
 DROP TABLE IF EXISTS FNodes;
-CREATE TABLE FNodes AS
+CREATE TABLE FNodes ENGINE = MEMORY AS
     SELECT
         1nid AS Fid,
         COLUMN_NAME AS FunctorName,
@@ -115,7 +115,7 @@ CREATE TABLE FNodes AS
 
 
 DROP TABLE IF EXISTS RNodes_pvars;
-CREATE TABLE RNodes_pvars AS
+CREATE TABLE RNodes_pvars ENGINE = MEMORY AS
     SELECT
         N.rnid,
         N.pvid,
@@ -131,7 +131,7 @@ CREATE TABLE RNodes_pvars AS
 
 /* Transfer pvariables.  Only those that occur in the functor set. */
 DROP TABLE IF EXISTS PVariables;
-CREATE TABLE PVariables AS
+CREATE TABLE PVariables ENGINE = MEMORY AS
     SELECT DISTINCT
         P.pvid,
         P.ID_COLUMN_NAME,
@@ -152,7 +152,7 @@ CREATE TABLE PVariables AS
  * FunctorSet.
  */
 DROP TABLE IF EXISTS LatticeRNodes;
-CREATE TABLE LatticeRNodes AS
+CREATE TABLE LatticeRNodes ENGINE = MEMORY AS
     SELECT
         LR.orig_rnid,
         LR.short_rnid


### PR DESCRIPTION
Just by changing the engine type from InnoDB to MEMORY for the metadata tables, we achieved about a 75% reduction in the runtime for that part of FactorBase.

Sample runtime before this change for UW on 01:
```
SUM(cascadeFS): 47334
SUM(lattice): 21368
SUM(populateMQ): 11191
SUM(populateMQRChain): 9233
Total (MetaData): 89126
```
Sample runtime after this change for UW on 01:
```
SUM(cascadeFS): 11724
SUM(lattice): 5593
SUM(populateMQ): 2898
SUM(populateMQRChain): 3249
Total (MetaData): 23464
```
I am just running this change on IMDB to see how this affects a larger database.

Update:
Here are the runtimes for IMDB (3 runs for ondemand and 3 runs for precount):
```
Ondemand (with projection):

real    107m47.843s
user    1m59.420s
sys     0m29.951s

real    107m11.925s
user    1m56.663s
sys     0m30.389s

real    109m57.326s
user    1m57.730s
sys     0m30.109s

Precount:
real    76m30.063s
user    86m9.794s
sys     2m45.036s

real    73m27.034s
user    72m13.358s
sys     2m27.314s

real    72m33.264s
user    66m52.547s
sys     1m58.527s
```
Looks like using MEMORY tables is okay for big databases.