### PR TITLE
TRUNCATE + INSERT memory tables

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -116,6 +116,11 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
             );
             MySQLScriptRunner.runScript(
                 this.dbConnection,
+                Config.SCRIPTS_DIRECTORY + "transfer_initialize.sql",
+                this.baseDatabaseName
+            );
+            MySQLScriptRunner.runScript(
+                this.dbConnection,
                 Config.SCRIPTS_DIRECTORY + "transfer_cascade.sql",
                 this.baseDatabaseName,
                 "//"

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -137,6 +137,11 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
             );
             MySQLScriptRunner.runScript(
                 this.dbConnection,
+                Config.SCRIPTS_DIRECTORY + "metaqueries_initialize.sql",
+                this.baseDatabaseName
+            );
+            MySQLScriptRunner.runScript(
+                this.dbConnection,
                 Config.SCRIPTS_DIRECTORY + "metaqueries_populate.sql",
                 this.baseDatabaseName,
                 "//"

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -110,6 +110,11 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
 
             MySQLScriptRunner.runScript(
                 this.dbConnection,
+                Config.SCRIPTS_DIRECTORY + "latticegenerator_initialize_local.sql",
+                this.baseDatabaseName
+            );
+            MySQLScriptRunner.runScript(
+                this.dbConnection,
                 Config.SCRIPTS_DIRECTORY + "latticegenerator_populate.sql",
                 this.baseDatabaseName,
                 "//"

--- a/code/factorbase/src/main/resources/scripts/latticegenerator_initialize_local.sql
+++ b/code/factorbase/src/main/resources/scripts/latticegenerator_initialize_local.sql
@@ -1,0 +1,30 @@
+/* Create the tables necessary for generating the lattice. */
+SET storage_engine=MEMORY;
+
+CREATE TABLE lattice_membership (
+    name VARCHAR(398),
+    member VARCHAR(398),
+    PRIMARY KEY(name, member)
+);
+
+
+CREATE TABLE lattice_rel (
+    parent VARCHAR(398),
+    child VARCHAR(398),
+    removed VARCHAR(199),
+    PRIMARY KEY(parent, child)
+);
+
+
+CREATE TABLE lattice_set (
+    name VARCHAR(199),
+    length INT(11),
+    PRIMARY KEY(name, length)
+);
+
+
+CREATE TABLE lattice_mapping (
+    orig_rnid VARCHAR(200),
+    short_rnid VARCHAR(20),
+    PRIMARY KEY(orig_rnid, short_rnid)
+);

--- a/code/factorbase/src/main/resources/scripts/latticegenerator_populate.sql
+++ b/code/factorbase/src/main/resources/scripts/latticegenerator_populate.sql
@@ -5,8 +5,8 @@
 CREATE PROCEDURE populateLattice()
 BEGIN
 
-DROP TABLE IF EXISTS lattice_membership;
-CREATE TABLE lattice_membership ENGINE = MEMORY AS
+TRUNCATE lattice_membership;
+INSERT INTO lattice_membership
     -- Get the "name"s and "member"s where the "name"s are unique to the local lattice.
     SELECT
         name,
@@ -36,8 +36,8 @@ CREATE TABLE lattice_membership ENGINE = MEMORY AS
     );
 
 
-DROP TABLE IF EXISTS lattice_rel;
-CREATE TABLE lattice_rel ENGINE = MEMORY AS
+TRUNCATE lattice_rel;
+INSERT INTO lattice_rel
     SELECT
         parent,
         child,
@@ -49,8 +49,8 @@ CREATE TABLE lattice_rel ENGINE = MEMORY AS
         LREL.removed = LR.orig_rnid;
 
 
-DROP TABLE IF EXISTS lattice_set;
-CREATE TABLE lattice_set ENGINE = MEMORY AS
+TRUNCATE lattice_set;
+INSERT INTO lattice_set
     SELECT
         LS.name,
         length
@@ -66,8 +66,8 @@ CREATE TABLE lattice_set ENGINE = MEMORY AS
         LS.name;
 
 
-DROP TABLE IF EXISTS lattice_mapping;
-CREATE TABLE lattice_mapping ENGINE = MEMORY AS
+TRUNCATE lattice_mapping;
+INSERT INTO lattice_mapping
     SELECT
         LMAP.orig_rnid,
         LMAP.short_rnid

--- a/code/factorbase/src/main/resources/scripts/metaqueries_initialize.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_initialize.sql
@@ -1,0 +1,11 @@
+/* Create the table necessary for storing metaquery information. */
+
+SET storage_engine=MEMORY;
+
+CREATE TABLE MetaQueries (
+    Lattice_Point varchar(199), /* e.g. pvid, rchain, prof0, a */
+    TableType varchar(100), /* e.g. star, flat, counts */
+    ClauseType varchar(10), /* FROM, WHERE, SELECT, GROUPBY */
+    EntryType varchar(100), /* e.g. 1node, aggregate like count */
+    Entries varchar(150)
+);

--- a/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
@@ -10,14 +10,7 @@
 CREATE PROCEDURE populateMQ()
 BEGIN
 
-DROP TABLE IF EXISTS MetaQueries;
-CREATE TABLE MetaQueries (
-    Lattice_Point varchar(199), /* e.g. pvid, rchain, prof0, a */
-    TableType varchar(100), /* e.g. star, flat, counts */
-    ClauseType varchar(10), /* FROM, WHERE, SELECT, GROUPBY */
-    EntryType varchar(100), /* e.g. 1node, aggregate like count */
-    Entries varchar(150)
-) ENGINE = MEMORY;
+TRUNCATE MetaQueries;
 
 /* metaqueries for population variables */
 

--- a/code/factorbase/src/main/resources/scripts/transfer_cascade.sql
+++ b/code/factorbase/src/main/resources/scripts/transfer_cascade.sql
@@ -3,8 +3,8 @@
 CREATE PROCEDURE cascadeFS()
 BEGIN
 
-DROP TABLE IF EXISTS 1Nodes;
-CREATE TABLE 1Nodes ENGINE = MEMORY AS
+TRUNCATE 1Nodes;
+INSERT INTO 1Nodes
     SELECT
         N.1nid,
         N.COLUMN_NAME,
@@ -17,8 +17,8 @@ CREATE TABLE 1Nodes ENGINE = MEMORY AS
         N.1nid = F.fid;
 
 
-DROP TABLE IF EXISTS 2Nodes;
-CREATE TABLE 2Nodes ENGINE = MEMORY AS
+TRUNCATE 2Nodes;
+INSERT INTO 2Nodes
     SELECT
         N.2nid,
         N.COLUMN_NAME,
@@ -34,8 +34,8 @@ CREATE TABLE 2Nodes ENGINE = MEMORY AS
 
 
 /* Map the 2nodes to rnodes for the given 2Nodes in the functor set. */
-DROP TABLE IF EXISTS RNodes_2Nodes;
-CREATE TABLE RNodes_2Nodes ENGINE = MEMORY AS
+TRUNCATE RNodes_2Nodes;
+INSERT INTO RNodes_2Nodes
     SELECT
         N.rnid,
         N.2nid,
@@ -48,8 +48,8 @@ CREATE TABLE RNodes_2Nodes ENGINE = MEMORY AS
 
 
 /* Copy the rnodes for the functor set. */
-DROP TABLE IF EXISTS RNodes;
-CREATE TABLE RNodes ENGINE = MEMORY AS
+TRUNCATE RNodes;
+INSERT INTO RNodes
     SELECT
         N.rnid,
         N.TABLE_NAME,
@@ -83,8 +83,8 @@ CREATE TABLE RNodes ENGINE = MEMORY AS
 
 
 /* Make comprehensive table for all functor nodes but restricted to the functor set. */
-DROP TABLE IF EXISTS FNodes;
-CREATE TABLE FNodes ENGINE = MEMORY AS
+TRUNCATE FNodes;
+INSERT INTO FNodes
     SELECT
         1nid AS Fid,
         COLUMN_NAME AS FunctorName,
@@ -114,8 +114,8 @@ CREATE TABLE FNodes ENGINE = MEMORY AS
         RNodes;
 
 
-DROP TABLE IF EXISTS RNodes_pvars;
-CREATE TABLE RNodes_pvars ENGINE = MEMORY AS
+TRUNCATE RNodes_pvars;
+INSERT INTO RNodes_pvars
     SELECT
         N.rnid,
         N.pvid,
@@ -130,8 +130,8 @@ CREATE TABLE RNodes_pvars ENGINE = MEMORY AS
 
 
 /* Transfer pvariables.  Only those that occur in the functor set. */
-DROP TABLE IF EXISTS PVariables;
-CREATE TABLE PVariables ENGINE = MEMORY AS
+TRUNCATE PVariables;
+INSERT INTO PVariables
     SELECT DISTINCT
         P.pvid,
         P.ID_COLUMN_NAME,
@@ -151,8 +151,8 @@ CREATE TABLE PVariables ENGINE = MEMORY AS
  * Prepare lattice generator by copying information from LatticeRNodes in the "_setup" database, restricted to the
  * FunctorSet.
  */
-DROP TABLE IF EXISTS LatticeRNodes;
-CREATE TABLE LatticeRNodes ENGINE = MEMORY AS
+TRUNCATE LatticeRNodes;
+INSERT INTO LatticeRNodes
     SELECT
         LR.orig_rnid,
         LR.short_rnid
@@ -161,9 +161,5 @@ CREATE TABLE LatticeRNodes ENGINE = MEMORY AS
         RNodes R
     WHERE
         LR.orig_rnid = R.rnid;
-
-
-ALTER TABLE LatticeRNodes
-    ADD UNIQUE INDEX rnid_UNIQUE (short_rnid ASC);
 
 END//

--- a/code/factorbase/src/main/resources/scripts/transfer_initialize.sql
+++ b/code/factorbase/src/main/resources/scripts/transfer_initialize.sql
@@ -1,0 +1,102 @@
+/* Create the tables necessary for cascading information based on the FunctorSet table. */
+SET storage_engine=MEMORY;
+
+CREATE TABLE 1Nodes AS
+    SELECT
+        N.1nid,
+        N.COLUMN_NAME,
+        N.pvid,
+        N.main
+    FROM
+        @database@_setup.1Nodes N
+    LIMIT
+        0;
+
+
+CREATE TABLE 2Nodes AS
+    SELECT
+        N.2nid,
+        N.COLUMN_NAME,
+        N.pvid1,
+        N.pvid2,
+        N.TABLE_NAME,
+        N.main
+    FROM
+        @database@_setup.2Nodes N
+    LIMIT
+        0;
+
+
+CREATE TABLE RNodes_2Nodes AS
+    SELECT
+        N.rnid,
+        N.2nid,
+        N.main
+    FROM
+        @database@_setup.RNodes_2Nodes N
+    LIMIT
+        0;
+
+
+CREATE TABLE RNodes AS
+    SELECT
+        N.rnid,
+        N.TABLE_NAME,
+        N.pvid1,
+        N.pvid2,
+        N.COLUMN_NAME1,
+        N.COLUMN_NAME2,
+        N.main
+    FROM
+        @database@_setup.RNodes N
+    LIMIT
+        0;
+
+
+/* Set up a table that contains all functor nodes of any arity.  Summarizes all the work we've done. */
+CREATE TABLE FNodes (
+    Fid varchar(199),
+    FunctorName varchar(64),
+    Type varchar(5),
+    main int(11),
+    PRIMARY KEY (Fid)
+);
+
+
+CREATE TABLE RNodes_pvars AS
+    SELECT
+        N.rnid,
+        N.pvid,
+        N.TABLE_NAME,
+        N.COLUMN_NAME,
+        N.REFERENCED_COLUMN_NAME
+    FROM
+        @database@_setup.RNodes_pvars N
+    LIMIT
+        0;
+
+
+CREATE TABLE PVariables AS
+    SELECT
+        N.pvid,
+        N.ID_COLUMN_NAME,
+        N.TABLE_NAME,
+        N.index_number
+    FROM
+        @database@_setup.PVariables N
+    LIMIT
+        0;
+
+
+CREATE TABLE LatticeRNodes AS
+    SELECT
+        orig_rnid,
+        short_rnid
+    FROM
+        @database@_setup.LatticeRNodes
+    LIMIT
+        0;
+
+
+ALTER TABLE LatticeRNodes
+    ADD UNIQUE INDEX rnid_UNIQUE (short_rnid ASC);


### PR DESCRIPTION
Creating tables, even when using MEMORY based ones, was the most expensive part of our stored procedure versions of the transfer script.

Since we are now using MEMORY based tables for the MetaData component of FactorBase, the cost to call TRUNCATE has been significantly reduced, which now allows us to use this strategy instead.  Using this strategy means we eliminate the table creation cost.

Sample runtime breakdown for UW_std on 01 before this change:
```
SUM(cascadeFS): 11724
SUM(lattice): 5593
SUM(populateMQ): 2898
SUM(populateMQRChain): 3249
Total (MetaData): 23464
```

Sample runtime breakdown for UW_std on 01 with this change:
```
SUM(cascadeFS): 2479
SUM(lattice): 2298
SUM(populateMQ): 2140
SUM(populateMQRChain): 3463
Total (MetaData): 10380
```
Note: Times are in ms and no changes were made to the populateMQRChain part, so the difference is just due to variation between each run.

I'm not sure if views would be any faster (might be a little faster though?), but I could try.  For now, this is probably the best if we want to avoid nested views.