### PR TITLE
Minor changes

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/app/RunBB.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/app/RunBB.java
@@ -15,6 +15,8 @@ import ca.sfu.cs.factorbase.lattice.RelationshipLattice;
 import ca.sfu.cs.factorbase.learning.BayesBaseH;
 import ca.sfu.cs.factorbase.learning.CountsManager;
 import ca.sfu.cs.factorbase.util.LoggerConfig;
+import ca.sfu.cs.factorbase.util.RuntimeLogger;
+
 import nu.xom.ParsingException;
 
 /**
@@ -39,7 +41,7 @@ public class RunBB {
         Config config = new Config();
         long configEnd = System.currentTimeMillis();
         logger.info("Start Program...");
-        logRunTime(logger, "Logger + Config Initialization", start, configEnd);
+        RuntimeLogger.logRunTime(logger, "Logger + Config Initialization", start, configEnd);
 
         long databaseStart = System.currentTimeMillis();
         FactorBaseDataBase factorBaseDatabase = new MySQLFactorBaseDataBase(
@@ -49,7 +51,7 @@ public class RunBB {
             config.getProperty("dbusername"),
             config.getProperty("dbpassword")
         );
-        logRunTime(logger, "Creating Database Connection", databaseStart, System.currentTimeMillis());
+        RuntimeLogger.logRunTime(logger, "Creating Database Connection", databaseStart, System.currentTimeMillis());
 
         // Generate the initial databases if specified to.
         long setupStart = System.currentTimeMillis();
@@ -58,23 +60,23 @@ public class RunBB {
         } else {
             logger.info("Databases are assumed to be setup!");
         }
-        logRunTime(logger, "Creating Setup Database", setupStart, System.currentTimeMillis());
+        RuntimeLogger.logRunTime(logger, "Creating Setup Database", setupStart, System.currentTimeMillis());
 
         // Generate the relationship lattice to guide the structure learning search.
         long globalLatticeStart = System.currentTimeMillis();
         RelationshipLattice globalLattice = factorBaseDatabase.getGlobalLattice();
-        logRunTime(logger, "Creating Global Lattice", globalLatticeStart, System.currentTimeMillis());
+        RuntimeLogger.logRunTime(logger, "Creating Global Lattice", globalLatticeStart, System.currentTimeMillis());
 
         // Learn a Bayesian Network.
         boolean usePreCounting = config.getProperty("PreCounting").equals("1");
         if (usePreCounting) {
             long buildCTStart = System.currentTimeMillis();
             CountsManager.buildCT();
-            logRunTime(logger, "Creating CT Tables", buildCTStart, System.currentTimeMillis());
+            RuntimeLogger.logRunTime(logger, "Creating CT Tables", buildCTStart, System.currentTimeMillis());
         } else {
             long buildGlobalCountsStart = System.currentTimeMillis();
             CountsManager.buildRChainsGlobalCounts();
-            logRunTime(logger, "Creating Global Counts Tables", buildGlobalCountsStart, System.currentTimeMillis());
+            RuntimeLogger.logRunTime(logger, "Creating Global Counts Tables", buildGlobalCountsStart, System.currentTimeMillis());
         }
 
         long bayesBaseHStart = System.currentTimeMillis();
@@ -83,27 +85,15 @@ public class RunBB {
             globalLattice,
             usePreCounting
         );
-        logRunTime(logger, "Running BayesBaseH", bayesBaseHStart, System.currentTimeMillis());
+        RuntimeLogger.logRunTime(logger, "Running BayesBaseH", bayesBaseHStart, System.currentTimeMillis());
 
         // Now eliminate temporary tables. Keep only the tables for the longest Rchain. Turn this off for debugging.
         long cleanupStart = System.currentTimeMillis();
         factorBaseDatabase.cleanupDatabase();
-        logRunTime(logger, "Cleanup Database", cleanupStart, System.currentTimeMillis());
+        RuntimeLogger.logRunTime(logger, "Cleanup Database", cleanupStart, System.currentTimeMillis());
 
-        logRunTime(logger, "Total", start, System.currentTimeMillis());
+        RuntimeLogger.logRunTime(logger, "Total", start, System.currentTimeMillis());
 
         logger.info("Program Done!");
-    }
-
-
-    /**
-     * Helper method to write out the run times in a consistent format.
-     * @param logger - the logger to write the runtime to.
-     * @param stage - the part of the FactorBase program that was run.
-     * @param start - the start time for the given stage (ms).
-     * @param end - the end time for the given stage (ms).
-     */
-    private static void logRunTime(Logger logger, String stage, long start, long end) {
-        logger.info("Runtime[" + stage + "]: " + String.valueOf(end - start) + "ms.");
     }
 }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
@@ -570,13 +570,13 @@ public class BayesBaseH {
 
         Statement st1 = con2.createStatement();
 
-        // TODO: Revisit how the orig_rnids are retrieved.
         ResultSet rs = st1.executeQuery(
-            "select orig_rnid as RChain " +
-            "from lattice_set " +
-            "join lattice_mapping " +
-            "on lattice_set.name = lattice_mapping.orig_rnid " +
-            "where lattice_set.length = 1;"
+            "SELECT " +
+                "name AS RChain " +
+            "FROM " +
+                "lattice_set " +
+            "WHERE " +
+                "lattice_set.length = 1;"
         );
 
         ArrayList<String> rnode_ids = new ArrayList<String>();

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
@@ -60,6 +60,7 @@ import ca.sfu.cs.factorbase.graph.Edge;
 import ca.sfu.cs.factorbase.jbn.BayesNet_Learning_main;
 import ca.sfu.cs.factorbase.lattice.RelationshipLattice;
 import ca.sfu.cs.factorbase.util.MySQLScriptRunner;
+import ca.sfu.cs.factorbase.util.RuntimeLogger;
 
 import com.mysql.jdbc.Connection;
 
@@ -115,7 +116,9 @@ public class BayesBaseH {
         String rchain = globalLattice.getLongestRChain();
 
         // Structure learning.
+        long start = System.currentTimeMillis();
         StructureLearning(database, con2, ctTablesGenerated, globalLattice);
+        RuntimeLogger.logRunTime(logger, "Structure Learning", start, System.currentTimeMillis());
 
         /**
          * OS: Nov 17, 2016. It can happen that Tetrad learns a forbidden edge. Argh. To catch this, we delete forbidden edges from any insertion. But then
@@ -152,33 +155,29 @@ public class BayesBaseH {
             if (Flag_UseLocal_CT) {
                 logger.fine("\n For BN_ScoreComputation.  use local_CT to compute the local_CP.");
             } else {
+                start = System.currentTimeMillis();
                 // For FunctorWrapper, do NOT have to use the local_CT, or HAVE TO change the weight learning part. June 18 2014.
                 CPGenerator.Generator(databaseName, con2); // May 22, 2014 zqian, computing the score for link analysis off.
                 CP mycp = new CP(databaseName2, databaseName3);
                 mycp.cp();
-                logger.fine("\n Parameter learning is done.");
-                //  For FunctorWrapper
+                RuntimeLogger.logRunTime(logger, "Parameter Learning", start, System.currentTimeMillis());
             }
 
             // Score Bayes net: compute KL divergence, and log-likelihood (average probability of node value given its Markov blanket, compared to database frequencies)
             // May 7th, zqian, For RDN do not need to do the smoothing
             // COMPUTE KLD
-            long l = System.currentTimeMillis(); // @zqian: measure structure learning time
-
+            start = System.currentTimeMillis();
             if (opt3.equals("1")) {
-                logger.fine("\n KLD_generator.KLDGenerator.");
                 KLD_generator.KLDGenerator(databaseName, con2);
+                RuntimeLogger.logRunTime(logger, "KLD Generator (KLDGenerator)", start, System.currentTimeMillis());
             } else {
-                logger.fine("\n KLD_generator.smoothed_CP.");
                 KLD_generator.smoothed_CP(rchain, con2);
+                RuntimeLogger.logRunTime(logger, "KLD Generator (Smoothed CP)", start, System.currentTimeMillis());
             }
 
             // Generating the bif file, in order to feed into UBC tool (bayes.jar). Based on the largest relationship chain.
             // Need CP tables.
             BIF_Generator.generate_bif(databaseName, "Bif_" + databaseName + ".xml", con2);
-
-            long l2 = System.currentTimeMillis(); // @zqian: measure structure learning time.
-            logger.fine("smoothed_CP Time(ms): " + (l2 - l) + " ms.\n");
         } else {
             logger.fine("\n Structure Learning is DONE. \n NO parameter learning for Continuous data."); // @zqian
         }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -461,7 +461,7 @@ public class CountsManager {
                     "SELECT " + CTJoinString + " " +
                     "FROM `" + cur_CT_Table + "` " +
 
-                    "UNION " +
+                    "UNION ALL " +
 
                     "SELECT " + CTJoinString + " " +
                     "FROM `" + cur_false_Table + "`, `" + rnid_or + "_join`";
@@ -890,7 +890,7 @@ public class CountsManager {
                     "SELECT " + UnionColumnString + " " +
                     "FROM `" + countsTableName + "` " +
 
-                    "UNION " +
+                    "UNION ALL " +
 
                     "SELECT " + UnionColumnString + " " +
                     "FROM `" + falseTableName + "`, `" + shortRchain + "_join`;";

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/RuntimeLogger.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/RuntimeLogger.java
@@ -1,0 +1,20 @@
+package ca.sfu.cs.factorbase.util;
+
+import java.util.logging.Logger;
+
+/**
+ * Class to help log information for a FactorBase run.
+ */
+public class RuntimeLogger {
+
+    /**
+     * Helper method to write out the run times in a consistent format.
+     * @param logger - the logger to write the runtime to.
+     * @param stage - the part of the FactorBase program that was run.
+     * @param start - the start time for the given stage (ms).
+     * @param end - the end time for the given stage (ms).
+     */
+    public static void logRunTime(Logger logger, String stage, long start, long end) {
+        logger.info("Runtime[" + stage + "]: " + String.valueOf(end - start) + "ms.");
+    }
+}


### PR DESCRIPTION
The two main changes I made are:

1.  Adjusted the CT table queries to use "UNION ALL" instead of "UNION" since we already know the UNIONed items will be unique.
2.  Removed an unnecessary JOIN from a query.
3.  Added additional runtime information for runBBH.

For point 3 the output looks like this now where we have a breakdown of runBBH.
```
Start Program...
Runtime[Logger + Config Initialization]: 4ms.
Runtime[Creating Database Connection]: 344ms.
Runtime[Creating Setup Database]: 35639ms.
Runtime[Creating Global Lattice]: 664ms.
Runtime[Creating CT Tables]: 12593ms.
Runtime[Structure Learning]: 7126ms.
Runtime[Parameter Learning]: 63193ms.
Runtime[KLD Generator (Smoothed CP)]: 26561ms.
Runtime[Running BayesBaseH]: 98039ms.
Runtime[Cleanup Database]: 2801ms.
Runtime[Total]: 150085ms.
Program Done!
```
Note: The sample output is using my own computer, which is why the runtimes seem quite different than usual.