### PR TITLE
Changed the "_flat" tables to be created using the MEMORY engine.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -417,7 +417,7 @@ public class CountsManager {
                         "FROM `" + cur_CT_Table + "`;";
                 }
 
-                String createStringflat = "create table "+cur_flat_Table+" as "+queryStringflat;
+                String createStringflat = "CREATE TABLE " + cur_flat_Table + " ENGINE = MEMORY AS " + queryStringflat;
                 logger.fine("\n create flat String : " + createStringflat );         
                 st3.execute(createStringflat);      //create flat table
 
@@ -765,7 +765,7 @@ public class CountsManager {
             }
 
             String flatTableName = shortRchain + "_flat";
-            String createString = "CREATE TABLE `" + flatTableName + "` AS " + queryString;
+            String createString = "CREATE TABLE `" + flatTableName + "` ENGINE = MEMORY AS " + queryString;
             logger.fine("\n create String : " + createString );
             st3.execute(createString);
 


### PR DESCRIPTION
- From experimentation, creating MEMORY tables and adding an index is
  faster than creating InnoDB tables and adding an index for the
  "_flat" tables so the "_flat" tables are now created using the
  MEMORY engine.
- MEMORY engine based tables have hash indices available, which are
  good for making equality comparisions.  The subtraction part of the
  Moebius Join matches rows exclusively using "=" comparisons so the
  hash indices work well for it.

Note: I am just trying this change on IMDB, but I'm pretty sure it should be okay :slightly_smiling_face: 