### PR TITLE
Refactor metaqueries extraction

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -951,9 +951,9 @@ public class CountsManager {
                 "AND TableType = 'Join';"
             );
 
-            String ColumnString = "`" + orig_rnid + "` VARCHAR(5)";
             List<String> columns = extractEntries(rs2, "Entries");
             String additionalColumns = makeDelimitedString(columns, ", ");
+            String ColumnString = "`" + orig_rnid + "` CHAR(1)";
             if (!additionalColumns.isEmpty()) {
                 ColumnString += ", " + additionalColumns;
             }


### PR DESCRIPTION
- Separated the column extraction logic from the query creation logic
  in the methods that are used to generate the SQL queries based on
  the content of the MetaQueries table.
- Created a new method called extractEntries() that retrieves the
  values from the specified column in the given ResultSet object and
  returns a List.
- Changed many methods to take in a List instead of a ResultSet, which
  makes the methods more flexible.
- With these changes I was able to remove two duplicate queries, which
  were previously needed because we didn't store the information
  extracted from the ResultSets in something like an ArrayList.
- Since the "_join" table only contains a single cell that has an "F",
  it is probably better to specify the datatype as CHAR(1) instead of
  VARCHAR(5), which requires more space than CHAR(1).