### PR TITLE
Replaced the database "_join" table with a derived table.

### DIFF
--- a/code/factorbase/src/main/resources/scripts/metaqueries_RChain.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_RChain.sql
@@ -11,9 +11,9 @@ SELECT
     'COLUMN' as ClauseType,
     '2nid' as EntryType,
     CONCAT(
-        '`',
+        '"N/A" AS `',
         2nid,
-        '` VARCHAR(5) DEFAULT "N/A"'
+        '`'
     ) AS Entries
 FROM
     RNodes_2Nodes N;

--- a/travis-resources/expected-output/mysql-extraction.txt
+++ b/travis-resources/expected-output/mysql-extraction.txt
@@ -213,8 +213,8 @@ RA(prof0,student0)	Flat	SELECT	1node	`popularity(prof0)`
 RA(prof0,student0)	Flat	SELECT	1node	`ranking(student0)`
 RA(prof0,student0)	Flat	SELECT	1node	`teachingability(prof0)`
 RA(prof0,student0)	Flat	SELECT	aggregate	SUM(`a_counts`.MULT) AS "MULT"
-RA(prof0,student0)	Join	COLUMN	2nid	`capability(prof0,student0)` VARCHAR(5) DEFAULT "N/A"
-RA(prof0,student0)	Join	COLUMN	2nid	`salary(prof0,student0)` VARCHAR(5) DEFAULT "N/A"
+RA(prof0,student0)	Join	COLUMN	2nid	"N/A" AS `capability(prof0,student0)`
+RA(prof0,student0)	Join	COLUMN	2nid	"N/A" AS `salary(prof0,student0)`
 RA(prof0,student0),registration(course0,student0)	Counts	FROM	rtable	unielwin.RA AS `RA(prof0,student0)`
 RA(prof0,student0),registration(course0,student0)	Counts	FROM	rtable	unielwin.registration AS `registration(course0,student0)`
 RA(prof0,student0),registration(course0,student0)	Counts	FROM	table	unielwin.course AS course0
@@ -312,8 +312,8 @@ registration(course0,student0)	Flat	SELECT	1node	`intelligence(student0)`
 registration(course0,student0)	Flat	SELECT	1node	`ranking(student0)`
 registration(course0,student0)	Flat	SELECT	1node	`rating(course0)`
 registration(course0,student0)	Flat	SELECT	aggregate	SUM(`b_counts`.MULT) AS "MULT"
-registration(course0,student0)	Join	COLUMN	2nid	`grade(course0,student0)` VARCHAR(5) DEFAULT "N/A"
-registration(course0,student0)	Join	COLUMN	2nid	`sat(course0,student0)` VARCHAR(5) DEFAULT "N/A"
+registration(course0,student0)	Join	COLUMN	2nid	"N/A" AS `grade(course0,student0)`
+registration(course0,student0)	Join	COLUMN	2nid	"N/A" AS `sat(course0,student0)`
 registration(course0,student0)	Star	FROM	table	course0_counts
 registration(course0,student0)	Star	FROM	table	student0_counts
 registration(course0,student0)	Star	SELECT	1nid	`diff(course0)`


### PR DESCRIPTION
- The cost to create the "_join" table is more noticeable with
  ondemand counting so it has been replaced with an equivalent
  derived table, i.e. we no longer create the "_join" tables!
- Updated the JOIN TableType in the MetaQueries table to support
  creating derived tables instead of database tables.
- Added more Javadoc.

Note: This change gives us a slight performance increase!