### PR TITLE
Made the column datatype more correct for the getColumnsInfo stored procedure

### DIFF
--- a/code/factorbase/src/main/resources/scripts/counts_storedprocedures.sql
+++ b/code/factorbase/src/main/resources/scripts/counts_storedprocedures.sql
@@ -2,12 +2,13 @@ CREATE PROCEDURE `getColumnsInfo`(tableNames TEXT)
 BEGIN
     SELECT
         column_name,
-        CONCAT(
-            data_type,
-            '(',
-            IFNULL(numeric_precision, character_maximum_length),
-            ')'
-        ) AS DataType
+        CASE WHEN
+            data_type = 'enum'
+        THEN
+            CONCAT("VARCHAR(", CHARACTER_MAXIMUM_LENGTH, ")")
+        ELSE
+            column_type
+        END AS DataType
     FROM
         information_schema.columns
     WHERE


### PR DESCRIPTION
- The previous implementation of the getColumnsInfo stored procedure
  didn't work for some data types such as enums.
- Updated the query used by the getColumnsInfo stored procedure to use
  the column_type  column, which seems to have the most correct
  information.