### PR TITLE
Changed the FunctorSet table to use the MEMORY engine.

### DIFF
--- a/code/factorbase/src/main/resources/scripts/metadata.sql
+++ b/code/factorbase/src/main/resources/scripts/metadata.sql
@@ -594,7 +594,7 @@ CREATE TABLE Groundings (pvid varchar(40), id varchar(256), primary key (pvid, i
 CREATE TABLE FunctorSet (
     Fid VARCHAR(199),
     PRIMARY KEY (Fid), FOREIGN KEY (Fid) REFERENCES FNodes(Fid)
-);
+) ENGINE = MEMORY;
 
 /* By default, FunctorSet contains all Fnodes */
 INSERT  INTO FunctorSet 


### PR DESCRIPTION
- Since the FunctorSet table has the TRUNCATE command called on it
  several times, it will be faster to use the MEMORY engine instead of
  InnoDB for this table.