### PR TITLE
Changed the "_false", "_star", "_counts", and "_CT" to MEMORY tables.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -401,7 +401,7 @@ public class CountsManager {
                 String rnid_or=removedShort;
             
                 String cur_star_Table = removedShort + len + "_" + fc + "_star";
-                String createStarString = "create table "+cur_star_Table +" as "+queryString;
+                String createStarString = "create table "+cur_star_Table +" ENGINE = MEMORY as "+queryString;
 
                 logger.fine("\n create star String : " + createStarString );
                 st3.execute(createStarString);      //create star table     
@@ -492,7 +492,7 @@ public class CountsManager {
                 cur_CT_Table = Next_CT_Table;
 
                 // Create CT table.
-                st3.execute("CREATE TABLE `" + Next_CT_Table + "` AS " + QueryStringCT);
+                st3.execute("CREATE TABLE `" + Next_CT_Table + "` ENGINE = MEMORY AS " + QueryStringCT);
                 rs1.previous();
 
                 fc++;   
@@ -622,7 +622,7 @@ public class CountsManager {
             }
 
             String countsTableName = pvid + "_counts";
-            String createString = "CREATE TABLE " + countsTableName + " AS " + queryString;
+            String createString = "CREATE TABLE " + countsTableName + " ENGINE = MEMORY AS " + queryString;
             logger.fine("Create String: " + createString);
             st3.execute(createString);
 
@@ -887,7 +887,7 @@ public class CountsManager {
             }
 
             String starTableName = shortRchain + "_star";
-            String createString = "CREATE TABLE `" + starTableName + "` AS " + queryString;
+            String createString = "CREATE TABLE `" + starTableName + "` ENGINE = MEMORY AS " + queryString;
             logger.fine("\n create String : " + createString );
             st3.execute(createString);
 
@@ -956,7 +956,7 @@ public class CountsManager {
 
             //join false table with join table to introduce rnid (=F) and 2nids (= n/a). Then union result with counts table.
             String createCTString =
-                "CREATE TABLE `" + ctTableName + "` AS " +
+                "CREATE TABLE `" + ctTableName + "` ENGINE = MEMORY AS " +
                     "SELECT " + UnionColumnString + " " +
                     "FROM `" + countsTableName + "` " +
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/QueryGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/QueryGenerator.java
@@ -191,7 +191,7 @@ public final class QueryGenerator {
         StringBuilder builder = new StringBuilder("CREATE TABLE ");
         builder.append("`" + tableName + "` (");
         builder.append(String.join(",", columns));
-        builder.append(");");
+        builder.append(") ENGINE = MEMORY;");
 
         return builder.toString();
     }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/Sort_merge3.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/Sort_merge3.java
@@ -64,7 +64,7 @@ public class Sort_merge3 {
             long time1 = System.currentTimeMillis();
 
             st2.execute("DROP TABLE IF EXISTS " + table3 + ";");
-            st2.execute("CREATE TABLE " + table3 + " SELECT * FROM " + table1 + " LIMIT 0;");
+            st2.execute("CREATE TABLE " + table3 + " ENGINE = MEMORY AS SELECT * FROM " + table1 + " LIMIT 0;");
             String query = "INSERT INTO " + table3 + " " + QueryGenerator.createSubtractionQuery(table1, table2, "MULT", orderList);
             st2.execute(query);
 
@@ -77,7 +77,7 @@ public class Sort_merge3 {
         } else { // Aug 18, 2014 zqian: Handle the extreme case when there's only `mult` column.
             logger.fine("\n \t Handle the extreme case when there's only `mult` column \n");
             st2.execute("DROP TABLE IF EXISTS " + table3 + ";");
-            st2.execute("CREATE TABLE " + table3 + " SELECT * FROM " + table1 + " LIMIT 0;");
+            st2.execute("CREATE TABLE " + table3 + " ENGINE = MEMORY AS SELECT * FROM " + table1 + " LIMIT 0;");
             logger.fine("INSERT INTO " + table3 + " SELECT (" + table1 + ".mult - " + table2 + ".mult) AS mult FROM " + table1 + ", " + table2 + ";");
             st2.execute("INSERT INTO " + table3 + " SELECT (" + table1 + ".mult - " + table2 + ".mult) AS mult FROM " + table1 + ", " + table2 + ";");
         }


### PR DESCRIPTION
- Changed the "_false", "_star", "_counts", and "_CT" to use the
  MEMORY engine.
- Using the unielwin dataset, it was observed that MEMORY tables
  performed better than InnoDB in terms of processing speed.