### PR TITLE
Generate counts/CT tables with non zero counts only.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/RelationshipLattice.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/RelationshipLattice.java
@@ -14,7 +14,6 @@ public class RelationshipLattice {
     private Map<Integer, List<FunctorNodesInfo>> rchainInfosPerLevel = new HashMap<Integer, List<FunctorNodesInfo>>();
     private int latticeHeight = 0;
     private String longestRChain;
-    private String longestRChainShortID;
 
 
     /**
@@ -45,16 +44,6 @@ public class RelationshipLattice {
 
 
     /**
-     * Retrieve the short version of the name of the longest RChain in the lattice.
-     *
-     * @return the short version of the name of the longest RChain in the lattice.
-     */
-    public String getLongestRChainShortID() {
-        return this.longestRChainShortID;
-    }
-
-
-    /**
      * Add the given functor node information of an RChain to the specified lattice level.
      *
      * @param rchainInfo - the functor node information of the RChain to add.
@@ -65,7 +54,6 @@ public class RelationshipLattice {
         if (level > this.latticeHeight) {
             this.latticeHeight = level;
             this.longestRChain = rchainInfo.getID();
-            this.longestRChainShortID = rchainInfo.getShortID();
         }
 
         this.rchainInfosPerLevel.computeIfAbsent(

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -194,21 +194,7 @@ public class CountsManager {
                 logger.fine(" Rchain! are done");
             }
         }
-        
 
-        //delete the tuples with MULT=0 in the biggest CT table
-        String BiggestRchain = relationshipLattice.getLongestRChainShortID();
-        logger.fine("\n BiggestRchain: " + BiggestRchain);
-
-        if (BiggestRchain != null)
-        {
-            try (Statement st_CT = con_CT.createStatement()) {
-                String deleteQuery = "DELETE FROM `" + BiggestRchain + "_CT` WHERE MULT = '0';";
-                logger.fine(deleteQuery);
-                st_CT.execute(deleteQuery);
-            }
-        }
-        
         long l2 = System.currentTimeMillis();  //@zqian
         logger.fine("Building Time(ms) for ALL CT tables:  "+(l2-l)+" ms.\n");
     }
@@ -471,13 +457,15 @@ public class CountsManager {
                 String QueryStringCT =
                     "SELECT " + CTJoinString + " " +
                     "FROM `" + cur_CT_Table + "` " +
+                    "WHERE MULT > 0 " +
 
                     "UNION ALL " +
 
                     "SELECT " + CTJoinString + " " +
                     "FROM " +
                         "`" + cur_false_Table + "`, " +
-                        "(" + joinTableQueries.get(rnid_or) + ") AS JOIN_TABLE;";
+                        "(" + joinTableQueries.get(rnid_or) + ") AS JOIN_TABLE " +
+                    "WHERE MULT > 0;";
 
                 String Next_CT_Table = "";
 
@@ -620,6 +608,8 @@ public class CountsManager {
                     queryString = queryString + " GROUP BY " + GroupByString;
                 }
             }
+
+            queryString += " HAVING MULT > 0";
 
             String countsTableName = pvid + "_counts";
             String createString = "CREATE TABLE " + countsTableName + " ENGINE = MEMORY AS " + queryString;
@@ -959,13 +949,15 @@ public class CountsManager {
                 "CREATE TABLE `" + ctTableName + "` ENGINE = MEMORY AS " +
                     "SELECT " + UnionColumnString + " " +
                     "FROM `" + countsTableName + "` " +
+                    "WHERE MULT > 0 " +
 
                     "UNION ALL " +
 
                     "SELECT " + UnionColumnString + " " +
                     "FROM " +
                         "`" + falseTableName + "`, " +
-                        "(" + joinTableQueries.get(shortRchain) + ") AS JOIN_TABLE;";
+                        "(" + joinTableQueries.get(shortRchain) + ") AS JOIN_TABLE " +
+                    "WHERE MULT > 0";
             logger.fine("\n create CT table String : " + createCTString );
             st3.execute(createCTString);
 


### PR DESCRIPTION
- Updated the queries that are used to generate the "_counts" tables
  for PVars and the queries that are used to generate the "_CT" tables
  so that they only contain non zero count rows.
- Removed the code that removes the 0 count rows from the largest CT
  table since they are removed when the table is created.
- Removed the getLongestRChainShortID() method from the
  RelationshipLattice object since it is no longer used.  It was used
  to help generate the name of the table for the longest RChain.