### PR TITLE
ContingencyTableGenerator Cache Improvements

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -789,7 +789,7 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
          * @return the {@code ContingencyTableGenerator} found in the cache or null if a match isn't found.
          */
         public ContingencyTableGenerator get(String context, Set<String> familySet) {
-            this.previousGeneratedKey = generateCacheKey(context, familySet);
+            this.previousGeneratedKey = generateCacheKey(familySet);
 
             if (this.cacheContext == null || !this.cacheContext.equals(context)) {
                 this.cacheContext = context;
@@ -803,15 +803,14 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
         /**
          * Generate the cache key based on the given information.
          *
-         * @param context - the lattice point that we are currently at in the relationship lattice.
          * @param familySet - the names of the nodes in the family.
-         * @return the cache key based on the given context and family set.
+         * @return the cache key based on the given family set.
          */
-        private static String generateCacheKey(String context, Set<String> familySet) {
+        private static String generateCacheKey(Set<String> familySet) {
             List<String> familyList = new ArrayList<String>(familySet);
             Collections.sort(familyList);
             String familyCSV = String.join(",", familyList);
-            return context + familyCSV;
+            return familyCSV;
         }
     }
 }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -764,6 +764,7 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
     private static class ContingencyTableGeneratorCache {
         private Map<String, ContingencyTableGenerator> cache = new HashMap<String, ContingencyTableGenerator>();
         private String previousGeneratedKey = null;
+        private String cacheContext = null;
 
 
         /**
@@ -789,6 +790,12 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
          */
         public ContingencyTableGenerator get(String context, Set<String> familySet) {
             this.previousGeneratedKey = generateCacheKey(context, familySet);
+
+            if (this.cacheContext == null || !this.cacheContext.equals(context)) {
+                this.cacheContext = context;
+                this.cache.clear();
+            }
+
             return this.cache.get(this.previousGeneratedKey);
         }
 


### PR DESCRIPTION
- When we change the lattice point that we are at during the structure
  learning search, the ContingencyTableGenerators in the cache are
  no longer useful (unless we apply modifications when computing
  scores), so the cache is cleared before adding new values into it.

Note: This change is just to help reduce memory consumption, which I'm not sure is an issue yet.

- I have added an additional major change to this pull request.  If a ContingencyTableGenerator that exactly matches the given family set can't be found in the cache, we check the cache to see if a ContingencyTableGenerator that is a superset of the given family can be found.