### PR TITLE
Added the class MySQLIntegrityConstraintViolationException to the inclusion list.

### DIFF
--- a/code/factorbase/pom.xml
+++ b/code/factorbase/pom.xml
@@ -139,6 +139,7 @@
                     <include>META-INF/services/java.sql.Driver</include>
                     <include>com/mysql/jdbc/authentication/*</include>
                     <include>com/mysql/jdbc/exceptions/jdbc4/CommunicationsException.class</include>
+                    <include>com/mysql/jdbc/exceptions/jdbc4/MySQLIntegrityConstraintViolationException.class</include>
                     <include>com/mysql/jdbc/exceptions/jdbc4/MySQLNonTransientConnectionException.class</include>
                     <include>com/mysql/jdbc/exceptions/jdbc4/MySQLSyntaxErrorException.class</include>
                     <include>com/mysql/jdbc/exceptions/*</include>


### PR DESCRIPTION
- Updated the POM file to include the class
  MySQLIntegrityConstraintViolationException, which is sometimes
  needed to properly throw certain types of JDBC MySQL exceptions.