### PR TITLE
Added an extra condition when creating the EntityTables.

### DIFF
--- a/code/factorbase/src/main/resources/scripts/metadata.sql
+++ b/code/factorbase/src/main/resources/scripts/metadata.sql
@@ -389,7 +389,7 @@ CREATE table RNodes_MO_NotSelf AS
             ForeignKeys_pvars.REFERENCED_TABLE_NAME,
             '(',
             PVariables.pvid,
-            ') = ',
+            ')=',
             ForeignKeys_pvars.pvid
         ) AS rnid,
         ForeignKeys_pvars.TABLE_NAME,
@@ -420,7 +420,7 @@ CREATE table RNodes_MO_Self AS
             ForeignKeys_pvars.REFERENCED_TABLE_NAME,
             '(',
             PVariables.pvid,
-            ') = ',
+            ')=',
             ForeignKeys_pvars.pvid
         ) AS rnid,
         ForeignKeys_pvars.TABLE_NAME,

--- a/code/factorbase/src/main/resources/scripts/metadata.sql
+++ b/code/factorbase/src/main/resources/scripts/metadata.sql
@@ -156,6 +156,8 @@ We begin with the populations or entities. These have only one primary key.
 CREATE TABLE EntityTables AS SELECT distinct TABLE_NAME, COLUMN_NAME FROM
     KeyColumns T
 WHERE
+    CONSTRAINT_NAME = 'PRIMARY'
+AND
     1 = (SELECT 
             COUNT(COLUMN_NAME)
         FROM

--- a/code/factorbase/src/main/resources/scripts/metadata.sql
+++ b/code/factorbase/src/main/resources/scripts/metadata.sql
@@ -409,7 +409,8 @@ CREATE table RNodes_MO_NotSelf AS
             AND RelationTables.TABLE_NAME = PVariables.TABLE_NAME
             AND RelationTables.TABLE_NAME = KeyColumns.TABLE_NAME
             AND RelationTables.SelfRelationship = 0
-            AND RelationTables.Many_OneRelationship = 1;
+            AND RelationTables.Many_OneRelationship = 1
+            AND KeyColumns.CONSTRAINT_NAME = 'PRIMARY';
 
 /*fourth case: many-one, self-relationship */
 


### PR DESCRIPTION
- Duplicate table names could appear in the EntityTables table due to
  things like secondary keys, so a restriction is placed to ensure
  that each table is listed at most once.