### PR TITLE
Removed the RNodes that are included when determining the count array size.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -420,14 +420,6 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
                 // Combine RNodes of the RChain with the parents to get our final set that has all the FunctorNodes
                 // except the child.
                 allFunctorNodesExceptChild.addAll(parents);
-
-                for (String rnode : rnodes) {
-                    // Update the total number of combination of states possible only if the RNode is not already in
-                    // the FunctorSet.
-                    if (!rnode.equals(child) && !parents.contains(rnode)) {
-                        totalNumberOfStates *= functorInfos.getNumberOfStates(rnode);
-                    }
-                }
             }
             this.dbConnection.setCatalog(this.dbInfo.getSetupDatabaseName());
             try (Statement statement = this.dbConnection.createStatement()) {


### PR DESCRIPTION
- When the size of the count array was determined for a given child
  variable and set of parent variables, the extra RNodes from the
  lattice point in the search were included, but they shouldn't be
  since they have nothing to do with the number of states possible for
  a given child variable and set of parent variables so this logic has
  been removed.