### PR TITLE
Handle the case when entity tables have no columns.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -324,6 +324,36 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
 
 
     /**
+     * Create mappings for all the RNodes of the input database to their FunctorNodeInfo object, which are set to null.
+     *
+     * @return a {@code Map} containing key:value pairs of RNodeID:FunctorNodeInfo.
+     * @throws DataBaseException if an error occurs when attempting to retrieve the information.
+     */
+    private Map<String, FunctorNodesInfo> createNullRNodeFunctorInfoMappings() throws DataBaseException {
+        Map<String, FunctorNodesInfo> rnodeFunctorInfoMappings = new HashMap<String, FunctorNodesInfo>();
+
+        String query =
+            "SELECT " +
+                "rnid " +
+            "FROM " +
+                this.dbInfo.getSetupDatabaseName() + ".RNodes;";
+
+        try (
+            Statement statement = this.dbConnection.createStatement();
+            ResultSet results = statement.executeQuery(query)
+        ) {
+            while (results.next()) {
+                rnodeFunctorInfoMappings.put(results.getString("rnid"), null);
+            }
+        } catch (SQLException e) {
+            throw new DataBaseException("Failed to retrieve all the RNodes of the input database.", e);
+        }
+
+        return rnodeFunctorInfoMappings;
+    }
+
+
+    /**
      * Retrieve the functor node information for all the RNodes.
      *
      * @return Information for all the functor nodes of each RNode in the database.
@@ -393,7 +423,10 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
             throw new DataBaseException("Failed to retrieve the functor nodes information for the RNodes.", e);
         }
 
-        return functorNodesInfos;
+        Map<String, FunctorNodesInfo> rnodeFunctorInfoMappings = createNullRNodeFunctorInfoMappings();
+        rnodeFunctorInfoMappings.putAll(functorNodesInfos);
+
+        return rnodeFunctorInfoMappings;
     }
 
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/LatticeGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/LatticeGenerator.java
@@ -155,7 +155,10 @@ public class LatticeGenerator {
         // for loop to merge all the functor node information into a single FunctorNodesInfo for the RChain.
         for (String rnodeID : rnodeIDs) {
             FunctorNodesInfo rnodeFunctorInfo = functorNodesInfos.get(rnodeID);
-            rchainFunctorNodeInfo.merge(rnodeFunctorInfo);
+            // Some RNodes don't have any 1Nodes or 2Nodes so there isn't anything to merge for these cases.
+            if (rnodeFunctorInfo != null) {
+                rchainFunctorNodeInfo.merge(rnodeFunctorInfo);
+            }
         }
 
         return rchainFunctorNodeInfo;


### PR DESCRIPTION
- When entity tables have no columns it prevents the Java code from
  retrieving all the RNodes information since we get the RNodes
  information when we are retrieving the 1Nodes and 2Nodes information
  for all the RNodes.  So now we have to manually retrieve the RNodes
  to handle the case when the entity tables have no columns.