### PR TITLE
Minor changes

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -809,6 +809,7 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
         connectionProperties.put("user", username);
         connectionProperties.put("password", password);
         connectionProperties.put("allowLoadLocalInfile", "true");
+        connectionProperties.put("serverTimezone", "PST");
 
         return connectionProperties;
     }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/RuntimeLogger.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/RuntimeLogger.java
@@ -5,7 +5,14 @@ import java.util.logging.Logger;
 /**
  * Class to help log information for a FactorBase run.
  */
-public class RuntimeLogger {
+public final class RuntimeLogger {
+
+    /**
+     * Private constructor to prevent instantiation of the utility class.
+     */
+    private RuntimeLogger() {
+    }
+
 
     /**
      * Helper method to write out the run times in a consistent format.


### PR DESCRIPTION
For some reason when I updated to the new MySQL Connector/J, when it tries to connect to a database, it used PDT for the time zone and it didn't like that resulting in FactorBase crashing so I'e changed the time zone to always be PST.

I've also made a couple minor changes to the RuntimeLogger, which are more of a best practice type of thing.