### PR TITLE
Added database logging to RuntimeLogger.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/database/MySQLFactorBaseDataBase.java
@@ -36,6 +36,7 @@ import ca.sfu.cs.factorbase.learning.CountsManager;
 import ca.sfu.cs.factorbase.util.KeepTablesOnly;
 import ca.sfu.cs.factorbase.util.MySQLScriptRunner;
 import ca.sfu.cs.factorbase.util.QueryGenerator;
+import ca.sfu.cs.factorbase.util.RuntimeLogger;
 
 public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
 
@@ -116,6 +117,11 @@ public class MySQLFactorBaseDataBase implements FactorBaseDataBase {
             // Switch to start using the BN database.
             this.dbConnection.setCatalog(this.dbInfo.getBNDatabaseName());
 
+            RuntimeLogger.setupLoggingTable(
+                this.dbConnection,
+                this.baseDatabaseName,
+                this.dbInfo.getBNDatabaseName()
+            );
             MySQLScriptRunner.runScript(
                 this.dbConnection,
                 Config.SCRIPTS_DIRECTORY + "latticegenerator_initialize_local.sql",

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -40,6 +40,7 @@ import ca.sfu.cs.factorbase.lattice.LatticeGenerator;
 import ca.sfu.cs.factorbase.lattice.RelationshipLattice;
 import ca.sfu.cs.factorbase.util.MySQLScriptRunner;
 import ca.sfu.cs.factorbase.util.QueryGenerator;
+import ca.sfu.cs.factorbase.util.RuntimeLogger;
 import ca.sfu.cs.factorbase.util.Sort_merge3;
 
 public class CountsManager {
@@ -74,6 +75,7 @@ public class CountsManager {
      * @throws SQLException if there are issues executing the SQL queries.
      */
     public static void buildCT(boolean projectCounts) throws SQLException {
+        RuntimeLogger.addLogEntry(dbConnection);
         try (Statement statement = dbConnection.createStatement()) {
             statement.execute("DROP SCHEMA IF EXISTS " + databaseName_CT + ";");
             statement.execute("CREATE SCHEMA " + databaseName_CT + " COLLATE utf8_general_ci;");
@@ -84,7 +86,9 @@ public class CountsManager {
         RelationshipLattice relationshipLattice = propagateFunctorSetInfo(dbConnection);
 
         // Build the counts tables for the RChains.
+        long start = System.currentTimeMillis();
         buildRChainCounts(databaseName_CT, relationshipLattice, projectCounts);
+        RuntimeLogger.updateLogEntry(dbConnection, "buildRChainCounts", System.currentTimeMillis() - start);
 
         // building CT tables for Rchain
         CTGenerator(relationshipLattice);
@@ -100,31 +104,39 @@ public class CountsManager {
      */
     private static RelationshipLattice propagateFunctorSetInfo(Connection dbConnection) throws SQLException {
         // Transfer metadata from the "_setup" database to the "_BN" database based on the FunctorSet.
+        long start = System.currentTimeMillis();
         MySQLScriptRunner.callSP(
             dbConnection,
             "cascadeFS"
         );
+        RuntimeLogger.updateLogEntry(dbConnection, "cascadeFS", System.currentTimeMillis() - start);
 
         // Generate the relationship lattice based on the FunctorSet.
+        start = System.currentTimeMillis();
         RelationshipLattice relationshipLattice = LatticeGenerator.generate(
             dbConnection,
             databaseName_std
         );
+        RuntimeLogger.updateLogEntry(dbConnection, "lattice", System.currentTimeMillis() - start);
 
         // TODO: Add support for Continuous = 1.
         if (cont.equals("1")) {
             throw new UnsupportedOperationException("Not Implemented Yet!");
         } else {
+            start = System.currentTimeMillis();
             MySQLScriptRunner.callSP(
                 dbConnection,
                 "populateMQ"
             );
+            RuntimeLogger.updateLogEntry(dbConnection, "populateMQ", System.currentTimeMillis() - start);
         }
 
+        start = System.currentTimeMillis();
         MySQLScriptRunner.callSP(
             dbConnection,
             "populateMQRChain"
         );
+        RuntimeLogger.updateLogEntry(dbConnection, "populateMQRChain", System.currentTimeMillis() - start);
 
         return relationshipLattice;
     }
@@ -162,7 +174,8 @@ public class CountsManager {
 
         long l = System.currentTimeMillis(); //@zqian : CT table generating time
            // handling Pvars, generating pvars_counts       
-        BuildCT_Pvars();
+        buildPVarsCounts();
+        RuntimeLogger.updateLogEntry(dbConnection, "buildPVarsCounts", System.currentTimeMillis() - l);
         
         // preparing the _join part for _CT tables
         Map<String, String> joinTableQueries = createJoinTableQueries();
@@ -172,6 +185,7 @@ public class CountsManager {
             // Retrieve the first level of the lattice.
             List<FunctorNodesInfo> rchainInfos = relationshipLattice.getRChainsInfo(1);
 
+            long start = System.currentTimeMillis();
             // Building the _flat tables.
             BuildCT_Rnodes_flat(rchainInfos);
 
@@ -190,6 +204,7 @@ public class CountsManager {
                 BuildCT_RChain_flat(rchainInfos, len, joinTableQueries);
                 logger.fine(" Rchain! are done");
             }
+            RuntimeLogger.updateLogEntry(dbConnection, "buildFlatStarCT", System.currentTimeMillis() - start);
         }
 
         long l2 = System.currentTimeMillis();  //@zqian
@@ -501,7 +516,7 @@ public class CountsManager {
 
 
     /* building pvars_counts*/
-    private static void BuildCT_Pvars() throws SQLException {
+    private static void buildPVarsCounts() throws SQLException {
         long l = System.currentTimeMillis(); //@zqian : measure structure learning time
         dbConnection.setCatalog(databaseName_BN);
         Statement st = dbConnection.createStatement();

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/RuntimeLogger.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/RuntimeLogger.java
@@ -1,6 +1,12 @@
 package ca.sfu.cs.factorbase.util;
 
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.logging.Logger;
+
+import ca.sfu.cs.common.Configuration.Config;
 
 /**
  * Class to help log information for a FactorBase run.
@@ -14,6 +20,11 @@ public final class RuntimeLogger {
     }
 
 
+    private static final String CALL_LOGS = "CallLogs";
+    private static int callCount = 0;
+    private static String dbName;
+
+
     /**
      * Helper method to write out the run times in a consistent format.
      * @param logger - the logger to write the runtime to.
@@ -23,5 +34,68 @@ public final class RuntimeLogger {
      */
     public static void logRunTime(Logger logger, String stage, long start, long end) {
         logger.info("Runtime[" + stage + "]: " + String.valueOf(end - start) + "ms.");
+    }
+
+
+    /**
+     * Create the "CallLogs" table within the specified database.
+     *
+     * @param dbConnection - connection to the database server to create the "CallLogs" table in.
+     * @param baseDatabaseName - the name of the input database to FactorBase.
+     * @param loggingTableDatabaseName - the name of the database to create the "CallLogs" table in.
+     * @throws SQLException if there is an issue creating the "CallLogs" table in the specified database.
+     * @throws IOException if there is an issue reading the logging script.
+     */
+    public static void setupLoggingTable(
+        Connection dbConnection,
+        String baseDatabaseName,
+        String loggingTableDatabaseName
+    ) throws SQLException, IOException {
+        dbName = loggingTableDatabaseName;
+        MySQLScriptRunner.runScript(
+            dbConnection,
+            Config.SCRIPTS_DIRECTORY + "logging.sql",
+            baseDatabaseName
+        );
+    }
+
+
+    /**
+     * Add a new log entry to the "CallLogs" table.
+     *
+     * @param dbConnection - connection to the database server containing the "CallLogs" table.
+     * @throws SQLException if there is an issue adding a new log entry.
+     */
+    public static void addLogEntry(Connection dbConnection) throws SQLException {
+        callCount++;
+        try (Statement st = dbConnection.createStatement()) {
+            st.executeUpdate(
+                "INSERT INTO " + dbName + "." + CALL_LOGS + " " +
+                    "(CallNumber) " +
+                "VALUES " +
+                    "('" + callCount + "')"
+            );
+        }
+    }
+
+
+    /**
+     * Update the log entry that was created from the last call to {@link RuntimeLogger#addLogEntry(Connection)}.
+     *
+     * @param dbConnection - connection to the database server containing the "CallLogs" table.
+     * @param columnName - the name of the column to update in the "CallLogs" table.
+     * @param runtime - the runtime to write in the specified column.
+     * @throws SQLException if there is an issue updating the log entry.
+     */
+    public static void updateLogEntry(Connection dbConnection, String columnName, long runtime) throws SQLException {
+        try (Statement st = dbConnection.createStatement()) {
+            st.executeUpdate(
+                "UPDATE " + dbName + "." + CALL_LOGS + " " +
+                "SET " +
+                    columnName + " = " + runtime + " " +
+                "WHERE " +
+                    "CallNumber = " + callCount
+            );
+        }
     }
 }

--- a/code/factorbase/src/main/resources/scripts/logging.sql
+++ b/code/factorbase/src/main/resources/scripts/logging.sql
@@ -1,0 +1,10 @@
+CREATE TABLE CallLogs (
+    CallNumber INT,
+    cascadeFS INT, -- MetaData
+    lattice INT, -- MetaData
+    populateMQ INT, -- MetaData
+    populateMQRChain INT, -- MetaData
+    buildPVarsCounts INT, -- Counts
+    buildRChainCounts INT, -- Counts
+    buildFlatStarCT INT -- Mobius Join
+);

--- a/travis-resources/dbdump.sh
+++ b/travis-resources/dbdump.sh
@@ -49,6 +49,11 @@ do
 
   for table in $tables
   do
+    if [[ $table == "CallLogs" ]]
+    then
+      continue
+    fi
+
     echo "  Extracting table: $table"
     echo "Table: $table" >> $output
     $mysqlCommand "use $database; select * from \`$table\`;" | sort >> $output


### PR DESCRIPTION
- Runtime information related to contingency table generation is now
  written to a "CallLogs" table within the "_BN" database.
- Added methods to RuntimeLogger for writing logging information to
  the "CallLogs" table.
- Created a new script, logging.sql, that creates the "CallLogs"
  table, which is used to help log the runtimes for each method call
  that is related to contingency table generation.
- Renamed the method BuildCT_Pvars() to buildPVarsCounts() to match
  the naming format of the method buildRChainCounts().
- Updated the dbdump.sh script so that it ignores the CallLogs table
  when generating the mysql-extraction.txt file since the runtime
  values are expected to differ slightly between FactorBase runs.