### PR TITLE
Adjusted value for MAX_NUM_OF_PVARS and updated a query.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/LatticeGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/lattice/LatticeGenerator.java
@@ -22,7 +22,7 @@ import ca.sfu.cs.factorbase.util.MySQLScriptRunner;
  * Assumes that a table LatticeRnodes has been generated. See transfer.sql.
  */
 public class LatticeGenerator {
-    private static final int MAX_NUM_OF_PVARS = 10;
+    private static final int MAX_NUM_OF_PVARS = 5;
     private static final String delimiter = ",";
 
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
@@ -72,6 +72,7 @@ public class BayesBaseH {
 
     // To be read from config.
     static String databaseName, databaseName2, databaseName3;
+    static String setupDatabaseName;
     static String dbUsername;
     static String dbPassword;
     static String dbaddress;
@@ -277,6 +278,7 @@ public class BayesBaseH {
         databaseName = conf.getProperty("dbname");
         databaseName2 = databaseName + "_BN";
         databaseName3 = databaseName + "_CT";
+        setupDatabaseName = databaseName + "_setup";
         dbUsername = conf.getProperty("dbusername");
         dbPassword = conf.getProperty("dbpassword");
         dbaddress = conf.getProperty("dbaddress");
@@ -363,10 +365,16 @@ public class BayesBaseH {
                 
                 database.insertLearnedEdges(id, graphEdges, "Entity_BayesNets", false);
             } else {
+                String selectQuery =
+                    "SELECT 1nid " +
+                    "FROM 1Nodes, " + setupDatabaseName + ".EntityTables " +
+                    "WHERE 1Nodes.pvid = CONCAT(" + setupDatabaseName + ".EntityTables.Table_name,'0') " +
+                    "AND 1Nodes.pvid = '" + id + "';";
+
                 Statement st2 = con2.createStatement();
                 // Insert the BN nodes into Entity_BayesNet.
-                logger.fine("SELECT 1nid FROM 1Nodes, EntityTables WHERE 1Nodes.pvid = CONCAT(EntityTables.Table_name,'0') AND 1Nodes.pvid = '" + id + "';");
-                ResultSet rs2 = st2.executeQuery("SELECT 1nid FROM 1Nodes, EntityTables WHERE 1Nodes.pvid = CONCAT(EntityTables.Table_name,'0') AND 1Nodes.pvid = '" + id + "';");
+                logger.fine(selectQuery);
+                ResultSet rs2 = st2.executeQuery(selectQuery);
                 String child = "";
 
                 while(rs2.next()) {


### PR DESCRIPTION
- Just wanted to mention that changing the value of MAX_NUM_OF_PVARS from 10 to 5 seems to have enabled us to process the VisualGenome dataset without directly restricting the height of the relationship lattice.  Instead the height of the relationship lattice is indirectly restricted via the MAX_NUM_OF_PVARS variable. 
- The only other change this pull request has is the minor adjustment to a query so that it reads the EntityTables table from the "_setup" database.