### PR TITLE
Minor adjustments

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -790,8 +790,6 @@ public class CountsManager {
 
         // Create FROM query string.
         String fromString = databaseName_global_counts + ".`" + countsTableName + "`";
-        List<String> fromAliases = new ArrayList<String>();
-        fromAliases.add(fromString);
 
         // If we aren't projecting from the global counts table, we need to retrieve the tables that need to be joined
         // in order to generate the counts table.
@@ -804,7 +802,7 @@ public class CountsManager {
                 "AND TableType = 'Counts';"
             );
 
-            fromAliases = extractEntries(rs3, "Entries");
+            List<String> fromAliases = extractEntries(rs3, "Entries");
             fromString = makeDelimitedString(fromAliases, ", ");
         }
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -81,7 +81,7 @@ public class CountsManager {
         RuntimeLogger.addLogEntry(dbConnection);
         try (Statement statement = dbConnection.createStatement()) {
             statement.execute("DROP SCHEMA IF EXISTS " + databaseName_CT + ";");
-            statement.execute("CREATE SCHEMA " + databaseName_CT + " COLLATE utf8_general_ci;");
+            statement.execute("CREATE SCHEMA " + databaseName_CT + " /*M!100316 COLLATE utf8_general_ci*/;");
         }
 
         // Propagate metadata based on the FunctorSet.

--- a/code/factorbase/src/main/resources/scripts/initialize_databases.sql
+++ b/code/factorbase/src/main/resources/scripts/initialize_databases.sql
@@ -1,5 +1,5 @@
 -- Initialize the databases required by FactorBase.
-SET collation_server = 'utf8_general_ci';
+/*M!100316 SET collation_server = 'utf8_general_ci';*/
 
 DROP SCHEMA IF EXISTS @database@_setup;
 CREATE SCHEMA @database@_setup;


### PR DESCRIPTION
The most important change in this pull request is the addition of executable comments, which will enable certain MySQL/MariaDB queries to be run depending on the version of MySQL/MariaDB that the database server is using.  This should make it so that I no longer need to keep changing these queries each time I need to recompile FactorBase for the old or new database servers.