### PR TITLE
Added a counts cache for population variables.

### DIFF
--- a/code/factorbase/src/main/resources/scripts/initialize_databases.sql
+++ b/code/factorbase/src/main/resources/scripts/initialize_databases.sql
@@ -12,3 +12,6 @@ CREATE SCHEMA @database@_CT;
 
 DROP SCHEMA IF EXISTS @database@_global_counts;
 CREATE SCHEMA @database@_global_counts;
+
+DROP SCHEMA IF EXISTS @database@_counts_cache;
+CREATE SCHEMA @database@_counts_cache;


### PR DESCRIPTION
- It was observed that we were regenerating the exact same "_counts"
  tables multiple times for the population variables since the "_CT"
  database is deleted each time the buildCT() method is called.
- Created a new "_counts_cache" database used to store the various
  combinations of columns used when generating the "_counts" tables
  for population variables.
- The "_counts" tables for population variables in the "_CT" database
  are now views that point to the correct "_counts" table in the
  counts cache database.
- Created a new @FunctionalInterface interface to help switch between
  generating the "_counts" tables by checking the cache first or just
  generating them from scratch always.
- Cleaned up some of the code.