### PR TITLE
Various Code Cleanup

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
@@ -285,20 +285,11 @@ public class BayesBaseH {
         opt3 = conf.getProperty("ComputeKLD");
         cont = conf.getProperty("Continuous");
         String strLinkAnalysis = conf.getProperty("LinkCorrelations");
-
-        if (strLinkAnalysis.equalsIgnoreCase("1")) {
-            linkAnalysis = true;
-        } else {
-            linkAnalysis = false;
-        }
+        linkAnalysis = strLinkAnalysis.equalsIgnoreCase("1");
 
         //zqian June 18, 2014
         String UseLocal_CT = conf.getProperty( "UseLocal_CT" );
-        if (UseLocal_CT.equalsIgnoreCase("1")) {
-            Flag_UseLocal_CT = true;
-        } else {
-            Flag_UseLocal_CT = false;
-        }
+        Flag_UseLocal_CT = UseLocal_CT.equalsIgnoreCase("1");
     }
 
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -39,6 +39,7 @@ import ca.sfu.cs.factorbase.database.MySQLFactorBaseDataBase;
 import ca.sfu.cs.factorbase.lattice.LatticeGenerator;
 import ca.sfu.cs.factorbase.lattice.RelationshipLattice;
 import ca.sfu.cs.factorbase.util.MySQLScriptRunner;
+import ca.sfu.cs.factorbase.util.QueryGenerator;
 import ca.sfu.cs.factorbase.util.RuntimeLogger;
 import ca.sfu.cs.factorbase.util.Sort_merge3;
 
@@ -593,17 +594,12 @@ public class CountsManager {
             String pvid = rs.getString("pvid");
             logger.fine("pvid : " + pvid);
             String countsTableName = pvid + "_counts";
-            String selectQuery =
-                "SELECT " +
-                    "Entries " +
-                "FROM " +
-                    "MetaQueries " +
-                "WHERE " +
-                    "Lattice_Point = '" + pvid + "' " +
-                "AND " +
-                    "ClauseType = 'SELECT' " +
-                "AND " +
-                    "TableType = 'Counts';";
+            String selectQuery = QueryGenerator.createMetaQueriesExtractionQuery(
+                pvid,
+                "Counts",
+                "SELECT",
+                false
+            );
 
             // Extract column aliases.
             List<String> columnAliases;
@@ -655,17 +651,12 @@ public class CountsManager {
         logger.fine("SELECT String: " + selectString);
 
         // Create FROM query.
-        String fromQuery =
-            "SELECT " +
-                "Entries " +
-            "FROM " +
-                "MetaQueries " +
-            "WHERE " +
-                "Lattice_Point = '" + pvid + "' " +
-            "AND " +
-                "ClauseType = 'FROM' " +
-            "AND " +
-                "TableType = 'Counts';";
+        String fromQuery = QueryGenerator.createMetaQueriesExtractionQuery(
+            pvid,
+            "Counts",
+            "FROM",
+            false
+        );
 
         String fromString;
         try(ResultSet rs = st.executeQuery(fromQuery)) {
@@ -674,17 +665,12 @@ public class CountsManager {
         }
 
         // Create GROUP BY query.
-        String groupbyQuery =
-            "SELECT " +
-                "Entries " +
-            "FROM " +
-                "MetaQueries " +
-            "WHERE " +
-                "Lattice_Point = '" + pvid + "' " +
-            "AND " +
-                "ClauseType = 'GROUPBY' " +
-            "AND " +
-                "TableType = 'Counts';";
+        String groupbyQuery = QueryGenerator.createMetaQueriesExtractionQuery(
+            pvid,
+            "Counts",
+            "GROUPBY",
+            false
+        );
 
         String groupbyString;
         try(ResultSet rs = st.executeQuery(groupbyQuery)) {
@@ -693,17 +679,12 @@ public class CountsManager {
         }
 
         // Create WHERE query (groundings) if applicable.
-        String whereQuery =
-            "SELECT " +
-                "Entries " +
-            "FROM " +
-                "MetaQueries " +
-            "WHERE " +
-                "Lattice_Point = '" + pvid + "' " +
-            "AND " +
-                "ClauseType = 'WHERE' " +
-            "AND " +
-                "TableType = 'Counts';";
+        String whereQuery = QueryGenerator.createMetaQueriesExtractionQuery(
+            pvid,
+            "Counts",
+            "WHERE",
+            false
+        );
 
         String whereString = "";
         try (ResultSet rsGrounding = st.executeQuery(whereQuery)) {
@@ -909,11 +890,12 @@ public class CountsManager {
         // in order to generate the counts table.
         if (!buildByProjection) {
             ResultSet rs3 = st2.executeQuery(
-                "SELECT DISTINCT Entries " +
-                "FROM MetaQueries " +
-                "WHERE Lattice_Point = '" + rchain + "' " +
-                "AND ClauseType = 'FROM' " +
-                "AND TableType = 'Counts';"
+                QueryGenerator.createMetaQueriesExtractionQuery(
+                    rchain,
+                    "Counts",
+                    "FROM",
+                    false
+                )
             );
 
             List<String> fromAliases = extractEntries(rs3, "Entries");
@@ -929,11 +911,12 @@ public class CountsManager {
         // from the global counts table.
         if (!buildByProjection) {
             ResultSet rs4 = st2.executeQuery(
-                "SELECT DISTINCT Entries " +
-                "FROM MetaQueries " +
-                "WHERE Lattice_Point = '" + rchain + "' " +
-                "AND ClauseType = 'WHERE' " +
-                "AND TableType = 'Counts';"
+                QueryGenerator.createMetaQueriesExtractionQuery(
+                    rchain,
+                    "Counts",
+                    "WHERE",
+                    false
+                )
             );
 
             List<String> columns = extractEntries(rs4, "Entries");
@@ -955,11 +938,12 @@ public class CountsManager {
         // Continuous probably requires a different approach.  OS August 22.
         if (!cont.equals("1")) {
             ResultSet rs_6 = st2.executeQuery(
-                "SELECT DISTINCT Entries " +
-                "FROM MetaQueries " +
-                "WHERE Lattice_Point = '" + rchain + "' " +
-                "AND ClauseType = 'GROUPBY' " +
-                "AND TableType = 'Counts';"
+                QueryGenerator.createMetaQueriesExtractionQuery(
+                    rchain,
+                    "Counts",
+                    "GROUPBY",
+                    false
+                )
             );
 
             List<String> columns = extractEntries(rs_6, "Entries");
@@ -1006,17 +990,12 @@ public class CountsManager {
         Statement statement = dbConnection.createStatement();
 
         // Create SELECT query string.
-        String selectQuery =
-            "SELECT DISTINCT " +
-                "Entries " +
-            "FROM " +
-                "MetaQueries " +
-            "WHERE " +
-                "Lattice_Point = '" + rnode + "' " +
-            "AND " +
-                "TableType = 'STAR' " +
-            "AND " +
-                "ClauseType = 'SELECT';";
+        String selectQuery = QueryGenerator.createMetaQueriesExtractionQuery(
+            rnode,
+            "Star",
+            "SELECT",
+            true
+        );
 
         List<String> columns;
         try (ResultSet result = statement.executeQuery(selectQuery)) {
@@ -1025,17 +1004,12 @@ public class CountsManager {
         String selectString = String.join(", ", columns);
 
         // Create * query string, which will be used for the "SELECT AS MULT".
-        String multiplicationQuery =
-            "SELECT DISTINCT " +
-                "Entries " +
-            "FROM " +
-                "MetaQueries " +
-            "WHERE " +
-                "Lattice_Point = '" + rnode + "' " +
-            "AND " +
-                "TableType = 'STAR' " +
-            "AND " +
-                "ClauseType = 'FROM';";
+        String multiplicationQuery = QueryGenerator.createMetaQueriesExtractionQuery(
+            rnode,
+            "Star",
+            "FROM",
+            false
+        );
 
         try (ResultSet result = statement.executeQuery(multiplicationQuery)) {
             columns = extractEntries(result, "Entries");
@@ -1089,17 +1063,12 @@ public class CountsManager {
         Statement statement = dbConnection.createStatement();
 
         // Create SELECT query string.
-        String selectQuery =
-            "SELECT DISTINCT " +
-                "Entries " +
-            "FROM " +
-                "MetaQueries " +
-            "WHERE " +
-                "Lattice_Point = '" + rnode + "' " +
-            "AND " +
-                "TableType = 'Flat' " +
-            "AND " +
-                "ClauseType = 'SELECT';";
+        String selectQuery = QueryGenerator.createMetaQueriesExtractionQuery(
+            rnode,
+            "Flat",
+            "SELECT",
+            false
+        );
 
         List<String> columns;
         try (ResultSet rs2 = statement.executeQuery(selectQuery)) {
@@ -1108,17 +1077,12 @@ public class CountsManager {
         String selectString = String.join(", ", columns);
 
         // Create FROM query string.
-        String fromQuery =
-            "SELECT DISTINCT " +
-                "Entries " +
-            "FROM " +
-                "MetaQueries " +
-            "WHERE " +
-                "Lattice_Point = '" + rnode + "' " +
-            "AND " +
-                "TableType = 'Flat' " +
-            "AND " +
-                "ClauseType = 'FROM';";
+        String fromQuery = QueryGenerator.createMetaQueriesExtractionQuery(
+            rnode,
+            "Flat",
+            "FROM",
+            false
+        );
         try (ResultSet result = statement.executeQuery(fromQuery)) {
             columns = extractEntries(result, "Entries");
         }
@@ -1129,17 +1093,12 @@ public class CountsManager {
 
         // Create GROUP BY query string.
         if (!cont.equals("1")) {
-            String groupByQuery =
-                "SELECT DISTINCT " +
-                    "Entries " +
-                "FROM " +
-                    "MetaQueries " +
-                "WHERE " +
-                    "Lattice_Point = '" + rnode + "' " +
-                "AND " +
-                    "TableType = 'Flat' " +
-                "AND " +
-                    "ClauseType = 'GROUPBY';";
+            String groupByQuery = QueryGenerator.createMetaQueriesExtractionQuery(
+                rnode,
+                "Flat",
+                "GROUPBY",
+                false
+            );
             try (ResultSet result = statement.executeQuery(groupByQuery)) {
                 columns = extractEntries(result, "Entries");
             }
@@ -1285,10 +1244,12 @@ public class CountsManager {
 
             //  create ColumnString
             ResultSet rs2 = st2.executeQuery(
-                "SELECT DISTINCT Entries " +
-                "FROM MetaQueries " +
-                "WHERE Lattice_Point = '" + orig_rnid + "' " +
-                "AND TableType = 'Join';"
+                QueryGenerator.createMetaQueriesExtractionQuery(
+                    orig_rnid,
+                    "Join",
+                    "COLUMN",
+                    false
+                )
             );
 
             List<String> columns = extractEntries(rs2, "Entries");

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -396,7 +396,7 @@ public class CountsManager {
                 //  create select query string  
                 ResultSet rs2 = st2.executeQuery("SELECT DISTINCT Entries FROM MetaQueries WHERE Lattice_Point = '" + rchain + "' and '"+removed+"' = EntryType and ClauseType = 'SELECT' and TableType = 'Star';");
                 List<String> columns = extractEntries(rs2, "Entries");
-                String selectString = makeDelimitedString(columns, ", ");
+                String selectString = String.join(", ", columns);
                 logger.fine("Select String : " + selectString);
                 rs2.close();
                 //  create mult query string
@@ -406,12 +406,12 @@ public class CountsManager {
                 logger.fine("Mult String : " + MultString+ " as `MULT`");
                 rs3.close();
                 //  create from query string
-                String fromString = makeDelimitedString(columns, ", ");
+                String fromString = String.join(", ", columns);
                 logger.fine("From String : " + fromString);          
                 //  create where query string
                 ResultSet rs5 = st2.executeQuery("SELECT DISTINCT Entries FROM MetaQueries WHERE Lattice_Point = '" + rchain + "' and '"+removed+"' = EntryType and ClauseType = 'WHERE' and TableType = 'Star';");
                 columns = extractEntries(rs5, "Entries");
-                String whereString = makeDelimitedString(columns, " AND ");
+                String whereString = String.join(" AND ", columns);
                logger.fine("Where String : " + whereString);
                 rs5.close();
                 //  create the final query
@@ -651,7 +651,7 @@ public class CountsManager {
     ) throws SQLException {
         dbConnection.setCatalog(databaseName_BN);
         Statement st = dbConnection.createStatement();
-        String selectString = makeDelimitedString(columnAliases, ", ");
+        String selectString = String.join(", ", columnAliases);
         logger.fine("SELECT String: " + selectString);
 
         // Create FROM query.
@@ -670,7 +670,7 @@ public class CountsManager {
         String fromString;
         try(ResultSet rs = st.executeQuery(fromQuery)) {
             List<String> tables = extractEntries(rs, "Entries");
-            fromString = makeDelimitedString(tables, ", ");
+            fromString = String.join(", ", tables);
         }
 
         // Create GROUP BY query.
@@ -689,7 +689,7 @@ public class CountsManager {
         String groupbyString;
         try(ResultSet rs = st.executeQuery(groupbyQuery)) {
             List<String> columns = extractEntries(rs, "Entries");
-            groupbyString = makeDelimitedString(columns, ", ");
+            groupbyString = String.join(", ", columns);
         }
 
         // Create WHERE query (groundings) if applicable.
@@ -709,7 +709,7 @@ public class CountsManager {
         try (ResultSet rsGrounding = st.executeQuery(whereQuery)) {
             List<String> predicates = extractEntries(rsGrounding, "Entries");
             if (!predicates.isEmpty()) {
-                whereString = " WHERE " + makeDelimitedString(predicates, " AND ");
+                whereString = " WHERE " + String.join(" AND ", predicates);
             }
         }
 
@@ -897,7 +897,7 @@ public class CountsManager {
             selectString = makeDelimitedString(selectAliases, ", ", "AS ");
             selectString = "SUM(MULT) AS MULT, " + selectString;
         } else {
-            selectString = makeDelimitedString(selectAliases, ", ");
+            selectString = String.join(", ", selectAliases);
         }
 
         logger.fine("SELECT String: " + selectString);
@@ -917,7 +917,7 @@ public class CountsManager {
             );
 
             List<String> fromAliases = extractEntries(rs3, "Entries");
-            fromString = makeDelimitedString(fromAliases, ", ");
+            fromString = String.join(", ", fromAliases);
         }
 
         logger.fine("FROM String: " + fromString);
@@ -937,7 +937,7 @@ public class CountsManager {
             );
 
             List<String> columns = extractEntries(rs4, "Entries");
-            whereString = makeDelimitedString(columns, " AND ");
+            whereString = String.join(" AND ", columns);
         }
 
         // Create the final query.
@@ -963,7 +963,7 @@ public class CountsManager {
             );
 
             List<String> columns = extractEntries(rs_6, "Entries");
-            String GroupByString = makeDelimitedString(columns, ", ");
+            String GroupByString = String.join(", ", columns);
 
             if (!GroupByString.isEmpty()) {
                 queryString = queryString + " GROUP BY "  + GroupByString;
@@ -1022,7 +1022,7 @@ public class CountsManager {
         try (ResultSet result = statement.executeQuery(selectQuery)) {
             columns = extractEntries(result, "Entries");
         }
-        String selectString = makeDelimitedString(columns, ", ");
+        String selectString = String.join(", ", columns);
 
         // Create * query string, which will be used for the "SELECT AS MULT".
         String multiplicationQuery =
@@ -1044,7 +1044,7 @@ public class CountsManager {
         String multiplicationString = makeStarSepQuery(columns);
 
         // Create FROM query string.
-        String fromString = makeDelimitedString(columns, ", ");
+        String fromString = String.join(", ", columns);
 
         // Create the final query string.
         String queryString = "SELECT " + multiplicationString + " AS MULT";
@@ -1105,7 +1105,7 @@ public class CountsManager {
         try (ResultSet rs2 = statement.executeQuery(selectQuery)) {
             columns = extractEntries(rs2, "Entries");
         }
-        String selectString = makeDelimitedString(columns, ", ");
+        String selectString = String.join(", ", columns);
 
         // Create FROM query string.
         String fromQuery =
@@ -1122,7 +1122,7 @@ public class CountsManager {
         try (ResultSet result = statement.executeQuery(fromQuery)) {
             columns = extractEntries(result, "Entries");
         }
-        String fromString = makeDelimitedString(columns, ", ");
+        String fromString = String.join(", ", columns);
 
         // Create the final query string.
         String queryString = "SELECT " + selectString + " FROM " + fromString;
@@ -1143,7 +1143,7 @@ public class CountsManager {
             try (ResultSet result = statement.executeQuery(groupByQuery)) {
                 columns = extractEntries(result, "Entries");
             }
-            String groupByString = makeDelimitedString(columns, ", ");
+            String groupByString = String.join(", ", columns);
             if (!groupByString.isEmpty()) {
                 queryString += " GROUP BY "  + groupByString;
             }
@@ -1292,7 +1292,7 @@ public class CountsManager {
             );
 
             List<String> columns = extractEntries(rs2, "Entries");
-            String additionalColumns = makeDelimitedString(columns, ", ");
+            String additionalColumns = String.join(", ", columns);
             StringBuilder joinTableQuerybuilder = new StringBuilder("SELECT \"F\" AS `" + orig_rnid + "`");
             if (!additionalColumns.isEmpty()) {
                 joinTableQuerybuilder.append(", " + additionalColumns);
@@ -1360,25 +1360,6 @@ public class CountsManager {
         }
 
         return escapedCSV.toString();
-    }
-
-
-    /**
-     * Generate a delimited string of columns.
-     *
-     * @param columns - the columns to make a delimited string with.
-     * @param delimiter - the delimiter to use for the delimited string.
-     * @return a delimited string of columns.
-     */
-    private static String makeDelimitedString(List<String> columns, String delimiter) {
-        String[] parts = new String[columns.size()];
-        int index = 0;
-        for (String column : columns) {
-            parts[index] = column;
-            index++;
-        }
-
-        return String.join(delimiter, parts);
     }
 
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -885,7 +885,7 @@ public class CountsManager {
 
         // Create SELECT query string.
         String selectQuery =
-            "SELECT DISTINCT Entries " +
+            "SELECT Entries " +
             "FROM MetaQueries " +
             "WHERE Lattice_Point = '" + rchain + "' " +
             "AND ClauseType = 'SELECT' ";

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -395,13 +395,29 @@ public class CountsManager {
                 Statement st2 = dbConnection.createStatement();
 
                 //  create select query string  
-                ResultSet rs2 = st2.executeQuery("SELECT DISTINCT Entries FROM MetaQueries WHERE Lattice_Point = '" + rchain + "' and '"+removed+"' = EntryType and ClauseType = 'SELECT' and TableType = 'Star';");
+                ResultSet rs2 = st2.executeQuery(
+                    QueryGenerator.createMetaQueriesExtractionQuery(
+                        rchain,
+                        "Star",
+                        "SELECT",
+                        removed,
+                        false
+                    )
+                );
                 List<String> columns = extractEntries(rs2, "Entries");
                 String selectString = String.join(", ", columns);
                 logger.fine("Select String : " + selectString);
                 rs2.close();
                 //  create mult query string
-                ResultSet rs3 = st2.executeQuery("SELECT DISTINCT Entries FROM MetaQueries WHERE Lattice_Point = '" + rchain + "' and '"+removed+"' = EntryType and ClauseType = 'FROM' and TableType = 'Star';");
+                ResultSet rs3 = st2.executeQuery(
+                    QueryGenerator.createMetaQueriesExtractionQuery(
+                        rchain,
+                        "Star",
+                        "FROM",
+                        removed,
+                        false
+                    )
+                );
                 columns = extractEntries(rs3, "Entries");
                 String MultString = makeStarSepQuery(columns);
                 logger.fine("Mult String : " + MultString+ " as `MULT`");
@@ -410,7 +426,15 @@ public class CountsManager {
                 String fromString = String.join(", ", columns);
                 logger.fine("From String : " + fromString);          
                 //  create where query string
-                ResultSet rs5 = st2.executeQuery("SELECT DISTINCT Entries FROM MetaQueries WHERE Lattice_Point = '" + rchain + "' and '"+removed+"' = EntryType and ClauseType = 'WHERE' and TableType = 'Star';");
+                ResultSet rs5 = st2.executeQuery(
+                    QueryGenerator.createMetaQueriesExtractionQuery(
+                        rchain,
+                        "Star",
+                        "WHERE",
+                        removed,
+                        false
+                    )
+                );
                 columns = extractEntries(rs5, "Entries");
                 String whereString = String.join(" AND ", columns);
                logger.fine("Where String : " + whereString);
@@ -598,6 +622,7 @@ public class CountsManager {
                 pvid,
                 "Counts",
                 "SELECT",
+                null,
                 false
             );
 
@@ -655,6 +680,7 @@ public class CountsManager {
             pvid,
             "Counts",
             "FROM",
+            null,
             false
         );
 
@@ -669,6 +695,7 @@ public class CountsManager {
             pvid,
             "Counts",
             "GROUPBY",
+            null,
             false
         );
 
@@ -683,6 +710,7 @@ public class CountsManager {
             pvid,
             "Counts",
             "WHERE",
+            null,
             false
         );
 
@@ -894,6 +922,7 @@ public class CountsManager {
                     rchain,
                     "Counts",
                     "FROM",
+                    null,
                     false
                 )
             );
@@ -915,6 +944,7 @@ public class CountsManager {
                     rchain,
                     "Counts",
                     "WHERE",
+                    null,
                     false
                 )
             );
@@ -942,6 +972,7 @@ public class CountsManager {
                     rchain,
                     "Counts",
                     "GROUPBY",
+                    null,
                     false
                 )
             );
@@ -994,6 +1025,7 @@ public class CountsManager {
             rnode,
             "Star",
             "SELECT",
+            null,
             true
         );
 
@@ -1008,6 +1040,7 @@ public class CountsManager {
             rnode,
             "Star",
             "FROM",
+            null,
             false
         );
 
@@ -1067,6 +1100,7 @@ public class CountsManager {
             rnode,
             "Flat",
             "SELECT",
+            null,
             false
         );
 
@@ -1081,6 +1115,7 @@ public class CountsManager {
             rnode,
             "Flat",
             "FROM",
+            null,
             false
         );
         try (ResultSet result = statement.executeQuery(fromQuery)) {
@@ -1097,6 +1132,7 @@ public class CountsManager {
                 rnode,
                 "Flat",
                 "GROUPBY",
+                null,
                 false
             );
             try (ResultSet result = statement.executeQuery(groupByQuery)) {
@@ -1248,6 +1284,7 @@ public class CountsManager {
                     orig_rnid,
                     "Join",
                     "COLUMN",
+                    null,
                     false
                 )
             );

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -47,7 +47,7 @@ public class CountsManager {
 
     private static Connection dbConnection;
     private static int tableID;
-    private static Map<String, String> pvarsCountsTableCache = new HashMap<String, String>();
+    private static Map<String, String> ctTablesCache = new HashMap<String, String>();
     private static String databaseName_std;
     private static String databaseName_BN;
     private static String databaseName_CT;
@@ -296,7 +296,7 @@ public class CountsManager {
         Config conf = new Config();
         databaseName_std = conf.getProperty("dbname");
         databaseName_BN = databaseName_std + "_BN";
-        databaseName_counts_cache = databaseName_std + "_counts_cache";
+        databaseName_counts_cache = databaseName_std + "_CT_cache";
         databaseName_global_counts = databaseName_std + "_global_counts";
         databaseName_CT = databaseName_std + "_CT";
         dbUsername = conf.getProperty("dbusername");
@@ -784,7 +784,7 @@ public class CountsManager {
 
         String countsTableCacheKey = csvJoiner.toString();
 
-        String cacheTableName = pvarsCountsTableCache.get(countsTableCacheKey);
+        String cacheTableName = ctTablesCache.get(countsTableCacheKey);
         if (cacheTableName == null) {
             cacheTableName = countsTableName + "_" + tableID;
             tableID++;
@@ -796,7 +796,7 @@ public class CountsManager {
                 pvid
             );
 
-            pvarsCountsTableCache.put(countsTableCacheKey, cacheTableName);
+            ctTablesCache.put(countsTableCacheKey, cacheTableName);
         }
 
         dbConnection.setCatalog(targetDatabaseName);

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -205,17 +205,22 @@ public class CountsManager {
         String storageEngine
     ) throws SQLException {
         for (FunctorNodesInfo rnodeInfo : rnodeInfos) {
+            String rnode = rnodeInfo.getID();
+            String shortRNode = rnodeInfo.getShortID();
+            logger.fine("RNode: " + rnode);
+            logger.fine("Short RNode: " + shortRNode);
+
             // Build the _star table.
-            buildRNodeStar(rnodeInfo);
+            buildRNodeStar(rnode, shortRNode);
 
             // Build the _flat table.
-            buildRNodeFlat(rnodeInfo, storageEngine);
+            buildRNodeFlat(rnode, shortRNode, storageEngine);
 
             // Build the _false table.
-            buildRNodeFalse(rnodeInfo);
+            buildRNodeFalse(shortRNode);
 
-            // Build the _false table first and then the _CT table.
-            buildRNodeCT(rnodeInfo, joinTableQueries, storageEngine);
+            // Build the _CT table.
+            buildRNodeCT(shortRNode, joinTableQueries, storageEngine);
         }
     }
 
@@ -1005,18 +1010,15 @@ public class CountsManager {
     /**
      * Create the star table for the given RNode.
      *
-     * @param rnodeInfo - {@code FunctorNodesInfo} for the RNode to build the "_star" table for.
+     * @param rnode - the name of the RNode to build the "_star" table for.
+     * @param shortRNode - the short name of the RNode to build the "_star" table for.
      * @throws SQLException if there are issues executing the SQL queries.
      */
     private static void buildRNodeStar(
-        FunctorNodesInfo rnodeInfo
+        String rnode,
+        String shortRNode
     ) throws SQLException {
         long start = System.currentTimeMillis(); // @zqian: measure structure learning time.
-        String rnode = rnodeInfo.getID();
-        logger.fine("\nRNode: " + rnode);
-        String shortRNode = rnodeInfo.getShortID();
-        logger.fine("Short RNode: " + shortRNode);
-
         dbConnection.setCatalog(databaseName_BN);
         Statement statement = dbConnection.createStatement();
 
@@ -1078,19 +1080,17 @@ public class CountsManager {
     /**
      * Create the flat table for the given RNode.
      *
-     * @param rnodeInfo - {@code FunctorNodesInfo} for the RNode to build the "_flat" table for.
+     * @param rnode - the name of the RNode to build the "_flat" table for.
+     * @param shortRNode - the short name of the RNode to build the "_flat" table for.
      * @param storageEngine - the storage engine to use for the table created when executing this method.
      * @throws SQLException if there are issues executing the SQL queries.
      */
     private static void buildRNodeFlat(
-        FunctorNodesInfo rnodeInfo,
+        String rnode,
+        String shortRNode,
         String storageEngine
     ) throws SQLException {
         long start = System.currentTimeMillis(); // @zqian: measure structure learning time.
-        String rnode = rnodeInfo.getID();
-        logger.fine("\nRNode: " + rnode);
-        String shortRNode = rnodeInfo.getShortID();
-        logger.fine("Short RNode: " + shortRNode);
 
         dbConnection.setCatalog(databaseName_BN);
         Statement statement = dbConnection.createStatement();
@@ -1170,11 +1170,10 @@ public class CountsManager {
     /**
      * Create the false table for the given RNode using the sort merge algorithm.
      *
-     * @param rnodeInfo - {@code FunctorNodesInfo} for the RNode to build the "_false" table for.
+     * @param shortRNode - the short name of the RNode to build the "_false" table for.
      * @throws SQLException if there are issues executing the SQL queries.
      */
-    private static void buildRNodeFalse(FunctorNodesInfo rnodeInfo) throws SQLException {
-        String shortRNode = rnodeInfo.getShortID();
+    private static void buildRNodeFalse(String shortRNode) throws SQLException {
         String falseTableName = shortRNode + "_false";
 
         // Computing the false table as the MULT difference between the matching rows of the star and flat tables.
@@ -1191,20 +1190,17 @@ public class CountsManager {
      * Create the CT table for the given RNode.  This is done by cross joining the "_false" table with the associated
      * JOIN (derived) table, and then having the result UNIONed with the proper "_counts" table.
      *
-     * @param rnodeInfo - {@code FunctorNodesInfo} for the RNode to build the "_CT" table for.
+     * @param shortRNode - the short name of the RNode to build the "_CT" table for.
      * @param joinTableQueries - {@code Map} to retrieve the associated query to create a derived JOIN table.
      * @param storageEngine - the storage engine to use for the table created when executing this method.
      * @throws SQLException if there are issues executing the SQL queries.
      */
     private static void buildRNodeCT(
-        FunctorNodesInfo rnodeInfo,
+        String shortRNode,
         Map<String, String> joinTableQueries,
         String storageEngine
     ) throws SQLException {
         long start = System.currentTimeMillis(); // @zqian: measure structure learning time.
-        logger.fine("\nRNode: " + rnodeInfo.getID());
-        String shortRNode = rnodeInfo.getShortID();
-        logger.fine("Short RNode: " + shortRNode);
 
         dbConnection.setCatalog(databaseName_CT);
         Statement statement = dbConnection.createStatement();

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/QueryGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/QueryGenerator.java
@@ -210,6 +210,8 @@ public final class QueryGenerator {
      * @param latticePoint - the point in the lattice that the "Entries" value belongs to.
      * @param tableType - the type of table the query we are trying to extract generates, e.g. STAR.
      * @param clause - the type of query we are trying to extract the "Entries" for, e.g. SELECT.
+     * @param entryType - the type of the "Entries" to extract, e.g. 1nid; if set to null will not be specified in the
+     *                    query.
      * @param selectDistinct - true if the DISTINCT keyword should be used; otherwise false.
      * @return a String that extracts "Entries" from the MetaQueries table based on the provided criteria.
      */
@@ -217,6 +219,7 @@ public final class QueryGenerator {
         String latticePoint,
         String tableType,
         String clause,
+        String entryType,
         boolean selectDistinct
     ) {
         builder.setLength(0);
@@ -228,7 +231,11 @@ public final class QueryGenerator {
         builder.append("FROM ").append("MetaQueries ");
         builder.append("WHERE ").append("Lattice_Point = '").append(latticePoint).append("' ");
         builder.append("AND ").append("TableType = '").append(tableType).append("' ");
-        builder.append("AND ").append("ClauseType = '").append(clause).append("';");
+        builder.append("AND ").append("ClauseType = '").append(clause);
+        if (entryType != null) {
+            builder.append("' AND ").append("EntryType = '").append(entryType);
+        }
+        builder.append("';");
 
         return builder.toString();
     }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/QueryGenerator.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/QueryGenerator.java
@@ -201,4 +201,35 @@ public final class QueryGenerator {
 
         return builder.toString();
     }
+
+
+    /**
+     * Generates a MySQL SELECT String that extracts "Entries" from the MetaQueries table based on the provided
+     * criteria.
+     *
+     * @param latticePoint - the point in the lattice that the "Entries" value belongs to.
+     * @param tableType - the type of table the query we are trying to extract generates, e.g. STAR.
+     * @param clause - the type of query we are trying to extract the "Entries" for, e.g. SELECT.
+     * @param selectDistinct - true if the DISTINCT keyword should be used; otherwise false.
+     * @return a String that extracts "Entries" from the MetaQueries table based on the provided criteria.
+     */
+    public static String createMetaQueriesExtractionQuery(
+        String latticePoint,
+        String tableType,
+        String clause,
+        boolean selectDistinct
+    ) {
+        builder.setLength(0);
+        if (selectDistinct) {
+            builder.append("SELECT DISTINCT Entries ");
+        } else {
+            builder.append("SELECT Entries ");
+        }
+        builder.append("FROM ").append("MetaQueries ");
+        builder.append("WHERE ").append("Lattice_Point = '").append(latticePoint).append("' ");
+        builder.append("AND ").append("TableType = '").append(tableType).append("' ");
+        builder.append("AND ").append("ClauseType = '").append(clause).append("';");
+
+        return builder.toString();
+    }
 }

--- a/code/factorbase/src/main/resources/scripts/initialize_databases.sql
+++ b/code/factorbase/src/main/resources/scripts/initialize_databases.sql
@@ -13,5 +13,5 @@ CREATE SCHEMA @database@_CT;
 DROP SCHEMA IF EXISTS @database@_global_counts;
 CREATE SCHEMA @database@_global_counts;
 
-DROP SCHEMA IF EXISTS @database@_counts_cache;
-CREATE SCHEMA @database@_counts_cache;
+DROP SCHEMA IF EXISTS @database@_CT_cache;
+CREATE SCHEMA @database@_CT_cache;

--- a/code/factorbase/src/main/resources/scripts/metaqueries_RChain.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_RChain.sql
@@ -209,7 +209,7 @@ where
 insert into MetaQueries
 SELECT
     lattice_rel.child as Lattice_Point, 
-    'STAR' as TableType, 
+    'Star' as TableType,
     'FROM' as ClauseType,
     lattice_rel.removed as EntryType, 
     /** rnid = lattice_rel.removed should now point to the R_i of our paper **/
@@ -235,7 +235,7 @@ where
 insert into MetaQueries
 SELECT DISTINCT 
     LR.child as Lattice_Point, 
-    'STAR' as TableType, 
+    'Star' as TableType,
     'FROM' as ClauseType,
     LR.removed as EntryType,
     CONCAT(
@@ -263,7 +263,7 @@ R.pvid not in (select pvid from RChain_pvars where RChain_pvars.rchain = LR.pare
 insert into MetaQueries
 SELECT DISTINCT 
      lattice_rel.child as Lattice_Point, 
-    'STAR' as TableType, 
+    'Star' as TableType,
     'WHERE' as ClauseType,
     lattice_rel.removed as EntryType, 
     CONCAT(
@@ -289,7 +289,7 @@ where
 insert into MetaQueries
 SELECT DISTINCT 
     lattice_rel.child AS Lattice_Point, 
-    'STAR' as TableType, 
+    'Star' as TableType,
     'SELECT' as ClauseType,
     lattice_rel.removed AS EntryType,
     M.Entries 
@@ -302,14 +302,14 @@ WHERE
         AND lattice_membership.name = lattice_rel.parent
         AND M.Lattice_Point = lattice_membership.`member`
         AND M.ClauseType = 'GROUPBY'
-        AND M.TableType = 'COUNTS';
+        AND M.TableType = 'Counts';
 
 
 /* find all elements in the groupBy List for the shortened parent rchain */
 insert into MetaQueries
 SELECT DISTINCT 
     LR.child as Lattice_Point, 
-    'STAR' as TableType, 
+    'Star' as TableType,
     'SELECT' as ClauseType,
     LR.removed as EntryType,
     M.Entries 
@@ -325,7 +325,7 @@ AND
 R.pvid not in (select pvid from RChain_pvars where RChain_pvars.rchain = LR.parent)
 AND M.Lattice_Point = R.pvid
 AND M.ClauseType = 'GROUPBY'
-AND M.TableType = 'COUNTS';
+AND M.TableType = 'Counts';
 /* The case where the parent is empty.*
  * In this case the rchain child contains just one rnid.
  * in this case we just insert the select entries from the star table for the rnide.
@@ -336,11 +336,18 @@ AND M.TableType = 'COUNTS';
 insert into MetaQueries
 SELECT DISTINCT 
     lattice_rel.removed AS Lattice_Point, 
-    'STAR' as TableType, 
+    'Star' as TableType,
     'SELECT' as ClauseType,
     lattice_rel.removed AS EntryType,
     M.Entries 
 FROM lattice_rel, MetaQueries M
-WHERE lattice_rel.parent = 'EmptySet' AND M.Lattice_Point = lattice_rel.removed AND M.TableType = 'STAR' and M.ClauseType = 'SELECT';
+WHERE
+    lattice_rel.parent = 'EmptySet'
+AND
+    M.Lattice_Point = lattice_rel.removed
+AND
+    M.TableType = 'Star'
+AND
+    M.ClauseType = 'SELECT';
 
 END//

--- a/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_populate.sql
@@ -288,6 +288,6 @@ INSERT INTO MetaQueries
     AND
         Lattice_Point = L.`member`
     AND
-        M.TableType = 'COUNTS';
+        M.TableType = 'Counts';
 
 END//

--- a/travis-resources/expected-output/mysql-extraction.txt
+++ b/travis-resources/expected-output/mysql-extraction.txt
@@ -249,39 +249,39 @@ RA(prof0,student0),registration(course0,student0)	Counts	WHERE	rtable	`RA(prof0,
 RA(prof0,student0),registration(course0,student0)	Counts	WHERE	rtable	`RA(prof0,student0)`.student_id = student0.student_id
 RA(prof0,student0),registration(course0,student0)	Counts	WHERE	rtable	`registration(course0,student0)`.course_id = course0.course_id
 RA(prof0,student0),registration(course0,student0)	Counts	WHERE	rtable	`registration(course0,student0)`.student_id = student0.student_id
-RA(prof0,student0),registration(course0,student0)	STAR	FROM	RA(prof0,student0)	`b_CT`
-RA(prof0,student0),registration(course0,student0)	STAR	FROM	RA(prof0,student0)	prof0_counts
-RA(prof0,student0),registration(course0,student0)	STAR	FROM	registration(course0,student0)	`a_CT`
-RA(prof0,student0),registration(course0,student0)	STAR	FROM	registration(course0,student0)	course0_counts
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	RA(prof0,student0)	`diff(course0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	RA(prof0,student0)	`grade(course0,student0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	RA(prof0,student0)	`intelligence(student0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	RA(prof0,student0)	`popularity(prof0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	RA(prof0,student0)	`ranking(student0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	RA(prof0,student0)	`rating(course0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	RA(prof0,student0)	`registration(course0,student0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	RA(prof0,student0)	`sat(course0,student0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	RA(prof0,student0)	`teachingability(prof0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`capability(prof0,student0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`diff(course0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`intelligence(student0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`popularity(prof0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`ranking(student0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`RA(prof0,student0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`rating(course0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`salary(prof0,student0)`
-RA(prof0,student0),registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`teachingability(prof0)`
-RA(prof0,student0),registration(course0,student0)	STAR	WHERE	RA(prof0,student0)	`registration(course0,student0)` = "T"
+RA(prof0,student0),registration(course0,student0)	Star	FROM	RA(prof0,student0)	`b_CT`
+RA(prof0,student0),registration(course0,student0)	Star	FROM	RA(prof0,student0)	prof0_counts
+RA(prof0,student0),registration(course0,student0)	Star	FROM	registration(course0,student0)	`a_CT`
+RA(prof0,student0),registration(course0,student0)	Star	FROM	registration(course0,student0)	course0_counts
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	RA(prof0,student0)	`diff(course0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	RA(prof0,student0)	`grade(course0,student0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	RA(prof0,student0)	`intelligence(student0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	RA(prof0,student0)	`popularity(prof0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	RA(prof0,student0)	`ranking(student0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	RA(prof0,student0)	`rating(course0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	RA(prof0,student0)	`registration(course0,student0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	RA(prof0,student0)	`sat(course0,student0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	RA(prof0,student0)	`teachingability(prof0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	registration(course0,student0)	`capability(prof0,student0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	registration(course0,student0)	`diff(course0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	registration(course0,student0)	`intelligence(student0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	registration(course0,student0)	`popularity(prof0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	registration(course0,student0)	`ranking(student0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	registration(course0,student0)	`RA(prof0,student0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	registration(course0,student0)	`rating(course0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	registration(course0,student0)	`salary(prof0,student0)`
+RA(prof0,student0),registration(course0,student0)	Star	SELECT	registration(course0,student0)	`teachingability(prof0)`
+RA(prof0,student0),registration(course0,student0)	Star	WHERE	RA(prof0,student0)	`registration(course0,student0)` = "T"
 RA(prof0,student0)	Star	FROM	table	prof0_counts
 RA(prof0,student0)	Star	FROM	table	student0_counts
 RA(prof0,student0)	Star	SELECT	1nid	`intelligence(student0)`
 RA(prof0,student0)	Star	SELECT	1nid	`popularity(prof0)`
 RA(prof0,student0)	Star	SELECT	1nid	`ranking(student0)`
 RA(prof0,student0)	Star	SELECT	1nid	`teachingability(prof0)`
-RA(prof0,student0)	STAR	SELECT	RA(prof0,student0)	`intelligence(student0)`
-RA(prof0,student0)	STAR	SELECT	RA(prof0,student0)	`popularity(prof0)`
-RA(prof0,student0)	STAR	SELECT	RA(prof0,student0)	`ranking(student0)`
-RA(prof0,student0)	STAR	SELECT	RA(prof0,student0)	`teachingability(prof0)`
+RA(prof0,student0)	Star	SELECT	RA(prof0,student0)	`intelligence(student0)`
+RA(prof0,student0)	Star	SELECT	RA(prof0,student0)	`popularity(prof0)`
+RA(prof0,student0)	Star	SELECT	RA(prof0,student0)	`ranking(student0)`
+RA(prof0,student0)	Star	SELECT	RA(prof0,student0)	`teachingability(prof0)`
 registration(course0,student0)	Counts	FROM	rtable	unielwin.registration AS `registration(course0,student0)`
 registration(course0,student0)	Counts	FROM	table	unielwin.course AS course0
 registration(course0,student0)	Counts	FROM	table	unielwin.student AS student0
@@ -320,10 +320,10 @@ registration(course0,student0)	Star	SELECT	1nid	`diff(course0)`
 registration(course0,student0)	Star	SELECT	1nid	`intelligence(student0)`
 registration(course0,student0)	Star	SELECT	1nid	`ranking(student0)`
 registration(course0,student0)	Star	SELECT	1nid	`rating(course0)`
-registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`diff(course0)`
-registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`intelligence(student0)`
-registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`ranking(student0)`
-registration(course0,student0)	STAR	SELECT	registration(course0,student0)	`rating(course0)`
+registration(course0,student0)	Star	SELECT	registration(course0,student0)	`diff(course0)`
+registration(course0,student0)	Star	SELECT	registration(course0,student0)	`intelligence(student0)`
+registration(course0,student0)	Star	SELECT	registration(course0,student0)	`ranking(student0)`
+registration(course0,student0)	Star	SELECT	registration(course0,student0)	`rating(course0)`
 student0	Counts	FROM	table	unielwin.student AS student0
 student0	Counts	GROUPBY	1node	`intelligence(student0)`
 student0	Counts	GROUPBY	1node	`ranking(student0)`


### PR DESCRIPTION
- Deleted the makeDelimitedString(List<String> columns, String delimiter) method since the logic it contained is no longer useful.
- Uses of the makeDelimitedString() method were replaced with equivalent String.join() calls.
- Use a single instance of StringBuilder for QueryGenerator so that we
  don't have to recreate the object.
- Added a new method to QueryGenerator that is used to generate queries to extract information from the MetaQueries table.
- Cleaned up some logic in BayesBaseH.java.
- Cleaned up some of the code for the buildRNode* methods.
- Renamed the "*_counts_cache" database to "*_CT_cache".
- Updated the buildRNodeCT() method to return a String instead of building a table (this will make it easier to add a cache for it).