### PR TITLE
Cleaned up some of the CT code.

### DIFF
--- a/code/componentsrunner/src/main/java/ca/sfu/cs/componentsrunner/app/RunComponent.java
+++ b/code/componentsrunner/src/main/java/ca/sfu/cs/componentsrunner/app/RunComponent.java
@@ -50,8 +50,7 @@ public class RunComponent {
                 dbConnection,
                 config.getProperty("SortMergeCartesianTable"),
                 config.getProperty("SortMergeSubsetTable"),
-                config.getProperty("SortMergeOutputTable"),
-                "InnoDB"
+                config.getProperty("SortMergeOutputTable")
             );
         } else if (component.equals("DataExtraction")) {
             System.out.println("Starting Data Extraction");

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -479,8 +479,7 @@ public class CountsManager {
                     dbConnection,
                     cur_star_Table,
                     cur_flat_Table,
-                    cur_false_Table,
-                    storageEngine
+                    cur_false_Table
                 );
 
                 long l5 = System.currentTimeMillis(); 
@@ -1140,8 +1139,7 @@ public class CountsManager {
                 dbConnection,
                 shortRchain + "_star",
                 shortRchain + "_flat",
-                falseTableName,
-                storageEngine
+                falseTableName
             );
 
             String countsTableName = shortRchain + "_counts";

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -367,7 +367,7 @@ public class CountsManager {
             dbConnection.setCatalog(databaseName_BN);
             Statement st1 = dbConnection.createStatement();
             ResultSet rs1 = st1.executeQuery(
-                "SELECT DISTINCT parent, removed, short_rnid " +
+                "SELECT removed, short_rnid " +
                 "FROM lattice_rel " +
                 "JOIN lattice_mapping " +
                 "ON lattice_rel.removed = lattice_mapping.orig_rnid " +
@@ -378,8 +378,6 @@ public class CountsManager {
             while(rs1.next())
             {       
                 long l2 = System.currentTimeMillis(); 
-                String parent = rs1.getString("parent");
-                logger.fine("\n parent : " + parent);
                 String removed = rs1.getString("removed");
                 logger.fine("\n removed : " + removed);  
                 String removedShort = rs1.getString("short_rnid");

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -200,7 +200,7 @@ public class CountsManager {
             BuildCT_Rnodes_flat(rchainInfos, storageEngine);
 
             // Building the _star tables.
-            BuildCT_Rnodes_star(rchainInfos, storageEngine);
+            BuildCT_Rnodes_star(rchainInfos);
 
             // Building the _false tables first and then the _CT tables.
             BuildCT_Rnodes_CT(rchainInfos, joinTableQueries, storageEngine);
@@ -427,7 +427,7 @@ public class CountsManager {
             
                 String cur_star_Table = removedShort + len + "_" + fc + "_star";
                 String createStarString =
-                    "CREATE TABLE " + cur_star_Table + " ENGINE = " + storageEngine + " AS " +
+                    "CREATE VIEW " + cur_star_Table + " AS " +
                     queryString;
 
                 logger.fine("\n create star String : " + createStarString );
@@ -1047,8 +1047,7 @@ public class CountsManager {
      * building the _star tables
      */
     private static void BuildCT_Rnodes_star(
-        List<FunctorNodesInfo> rchainInfos,
-        String storageEngine
+        List<FunctorNodesInfo> rchainInfos
     ) throws SQLException {
         long l = System.currentTimeMillis(); //@zqian : measure structure learning time
         for (FunctorNodesInfo rchainInfo : rchainInfos) {
@@ -1091,7 +1090,7 @@ public class CountsManager {
             Statement st3 = dbConnection.createStatement();
             String starTableName = shortRchain + "_star";
             String createString =
-                "CREATE TABLE `" + starTableName + "` ENGINE = " + storageEngine + " AS " +
+                "CREATE VIEW `" + starTableName + "` AS " +
                 queryString;
             logger.fine("\n create String : " + createString );
             st3.execute(createString);

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -186,7 +186,7 @@ public class CountsManager {
            // handling Pvars, generating pvars_counts       
         buildPVarsCounts(storageEngine, useCountsCache);
         RuntimeLogger.updateLogEntry(dbConnection, "buildPVarsCounts", System.currentTimeMillis() - l);
-        
+
         // preparing the _join part for _CT tables
         Map<String, String> joinTableQueries = createJoinTableQueries();
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/Sort_merge3.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/Sort_merge3.java
@@ -39,15 +39,13 @@ public class Sort_merge3 {
      * @param table2 - the table to match rows with in {@code table1} and subtract by the values found in the
      *                 MULT column.
      * @param outputTableName - the table to generate containing the results of the sort merge.
-     * @param storageEngine - the storage engine to use for the tables created when executing this method.
      * @throws SQLException if there are issues executing the queries.
      */
     public static void sort_merge(
         Connection conn,
         String table1,
         String table2,
-        String outputTableName,
-        String storageEngine
+        String outputTableName
     ) throws SQLException {
         logger.fine("\nGenerating false table by Subtraction using Sort_merge, cur_false_Table is: " + outputTableName);
 
@@ -57,7 +55,6 @@ public class Sort_merge3 {
         outputTableName = "`" + outputTableName + "`";
 
         Statement st1 = conn.createStatement();
-        Statement st2 = conn.createStatement();
 
         ArrayList<String> orderList = new ArrayList<String>();
 
@@ -75,22 +72,29 @@ public class Sort_merge3 {
         rst.close();
         st1.close();
 
+        // Code for merging the two tables.
+        String createQuery;
         if (orderList.size() > 0) {
-            // Code for merging the two tables.
-            long time1 = System.currentTimeMillis();
-            st2.execute("DROP TABLE IF EXISTS " + outputTableName + ";");
-            st2.execute(
-                "CREATE TABLE " + outputTableName + " ENGINE = " + storageEngine + " AS " +
-                QueryGenerator.createSubtractionQuery(table1, table2, "MULT", orderList)
-            );
-            st2.close();
-            logger.fine("\ntotal time: " + (System.currentTimeMillis() - time1) + "\n");
-        } else { // Aug 18, 2014 zqian: Handle the extreme case when there's only `mult` column.
-            logger.fine("\n \t Handle the extreme case when there's only `mult` column \n");
-            st2.execute("DROP TABLE IF EXISTS " + outputTableName + ";");
-            st2.execute("CREATE TABLE " + outputTableName + " ENGINE = MEMORY AS SELECT * FROM " + table1 + " LIMIT 0;");
-            logger.fine("INSERT INTO " + outputTableName + " SELECT (" + table1 + ".mult - " + table2 + ".mult) AS mult FROM " + table1 + ", " + table2 + ";");
-            st2.execute("INSERT INTO " + outputTableName + " SELECT (" + table1 + ".mult - " + table2 + ".mult) AS mult FROM " + table1 + ", " + table2 + ";");
+            createQuery =
+                "CREATE VIEW " + outputTableName + " AS " +
+                QueryGenerator.createSubtractionQuery(table1, table2, "MULT", orderList);
+        } else {
+            // Aug 18, 2014 zqian: Handle the extreme case when there's only the `MULT` column.
+            logger.fine("\n\tHandle the extreme case when there's only the `MULT` column.\n");
+            createQuery =
+                "CREATE VIEW " + outputTableName + " AS " +
+                "SELECT (" + table1 + ".MULT - " + table2 + ".MULT) AS MULT " +
+                "FROM " + table1 + ", " + table2 + ";";
         }
+
+        logger.fine(createQuery);
+
+        long time1 = System.currentTimeMillis();
+        try (Statement st2 = conn.createStatement()) {
+            st2.execute("DROP VIEW IF EXISTS " + outputTableName + ";");
+            st2.execute(createQuery);
+        }
+
+        logger.fine("\ntotal time: " + (System.currentTimeMillis() - time1) + "\n");
     }
 }

--- a/code/factorbase/src/test/java/ca/sfu/cs/factorbase/util/Sort_merge3Test.java
+++ b/code/factorbase/src/test/java/ca/sfu/cs/factorbase/util/Sort_merge3Test.java
@@ -24,8 +24,7 @@ public class Sort_merge3Test {
             db.con,
             "sort-merge-t1",
             "sort-merge-t2",
-            SORT_MERGE_TABLE,
-            "InnoDB"
+            SORT_MERGE_TABLE
         );
 
         Statement st = db.con.createStatement();
@@ -80,7 +79,7 @@ public class Sort_merge3Test {
         // Clean up the output sort merge table.
         st.executeUpdate(
             MessageFormat.format(
-                "DROP TABLE {0}",
+                "DROP VIEW {0}",
                 "`" + SORT_MERGE_TABLE + "`"
             )
         );


### PR DESCRIPTION
- Moved the BuildCT_Rnodes_* methods into a separate method called
  buildRNodesCT() to help organize the code.
- Renamed the BuildCT_RChain_flat() method to buildRChainsCT() to
  better match the new buildRNodesCT() method.
- Moved a large block of comments from the CTGenerator() method to the
  buildRChainsCT() method since they seemed to make more sense for the
  buildRChainsCT() method.
- The "parent" column was included for a SELECT query in the
  buildRChainsCT() method, but wasn't used for anything useful so it
  has been removed from the query.
- Also removed the DISTINCT keyword since it's not necessary.
- Made some minor adjustments to some of the comments.
- Removed some unnecessary comments and logger statements.
- Cleaned up some white-space.

Note: Most of these changes are to help with future changes to add a cache on the database side for "_CT" tables.