### PR TITLE
Moved the view in metaqueries_RChain.sql to metaqueries_initialize.sql.

### DIFF
--- a/code/factorbase/src/main/resources/scripts/metaqueries_RChain.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_RChain.sql
@@ -196,16 +196,8 @@ SELECT DISTINCT rnid, concat('`',replace(rnid, '`', ''),'_star`.',1nid,'=','`',r
 /*****************
  * start with from list
  */
-    
-CREATE or REPLACE VIEW RChain_pvars AS
-select  distinct 
-    M.name as rchain, 
-    pvid 
-from 
-    lattice_membership M, RNodes_pvars R
-where 
-    R.rnid = M.member;
-    
+
+
 insert into MetaQueries
 SELECT
     lattice_rel.child as Lattice_Point, 

--- a/code/factorbase/src/main/resources/scripts/metaqueries_initialize.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_initialize.sql
@@ -1,4 +1,4 @@
-/* Create the table necessary for storing metaquery information. */
+/* Create the table and view necessary for storing metaquery information. */
 
 SET storage_engine=MEMORY;
 
@@ -9,3 +9,14 @@ CREATE TABLE MetaQueries (
     EntryType varchar(100), /* e.g. 1node, aggregate like count */
     Entries varchar(150)
 );
+
+
+CREATE VIEW RChain_pvars AS
+    SELECT DISTINCT
+        M.name AS rchain,
+        pvid
+    FROM
+        lattice_membership M,
+        RNodes_pvars R
+    WHERE
+        R.rnid = M.member;


### PR DESCRIPTION
- Moved the view in metaqueries_RChain.sql to
  metaqueries_initialize.sql since there is no point regenerating the
  view multiple times.
- This change makes generation of the MetaQueries table faster.