### PR TITLE
Subqueries for "_false" and "_star" tables.

### DIFF
--- a/code/componentsrunner/src/main/configs/components-runner.cfg
+++ b/code/componentsrunner/src/main/configs/components-runner.cfg
@@ -8,7 +8,7 @@ dbpassword = 123456
 component = SortMerge
 
 # Sort Merge Configurations
-SortMergeCartesianTable = b3_1_star
+SortMergeCartesianTableSubQuery = SELECT * FROM b3_1_star
 SortMergeSubsetTable = b3_1_flat
 SortMergeOutputTable = components_runner_b3_1_false
 

--- a/code/componentsrunner/src/main/java/ca/sfu/cs/componentsrunner/app/RunComponent.java
+++ b/code/componentsrunner/src/main/java/ca/sfu/cs/componentsrunner/app/RunComponent.java
@@ -17,7 +17,7 @@ import ca.sfu.cs.factorbase.util.Sort_merge3;
 
 
 public class RunComponent {
-    private static final String CONNECTION_STRING = "jdbc:{0}/{1}";
+    private static final String CONNECTION_STRING = "jdbc:{0}/{1}?{2}";
 
     /**
      * Helper method to wrap the given string with backticks so that the SQL queries are valid.
@@ -33,7 +33,8 @@ public class RunComponent {
         String connectionString = MessageFormat.format(
             CONNECTION_STRING,
             config.getProperty("dbaddress"),
-            config.getProperty("dbname")
+            config.getProperty("dbname"),
+            "serverTimezone=PST"
         );
 
         Connection dbConnection = (Connection) DriverManager.getConnection(

--- a/code/componentsrunner/src/main/java/ca/sfu/cs/componentsrunner/app/RunComponent.java
+++ b/code/componentsrunner/src/main/java/ca/sfu/cs/componentsrunner/app/RunComponent.java
@@ -5,6 +5,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.text.MessageFormat;
 
 import ca.sfu.cs.common.Configuration.Config;
@@ -46,12 +47,18 @@ public class RunComponent {
         long startTime = System.currentTimeMillis();
         if (component.equals("SortMerge")) {
             System.out.println("Starting Sort Merge!");
-            Sort_merge3.sort_merge(
+            String falseTableSubQuery = Sort_merge3.sort_merge(
                 dbConnection,
+                config.getProperty("dbname"),
                 config.getProperty("SortMergeCartesianTable"),
-                config.getProperty("SortMergeSubsetTable"),
-                config.getProperty("SortMergeOutputTable")
+                config.getProperty("SortMergeSubsetTable")
             );
+            try (Statement statement = dbConnection.createStatement()) {
+                statement.executeUpdate(
+                    "CREATE VIEW " + config.getProperty("SortMergeOutputTable") + " AS " +
+                    falseTableSubQuery
+                );
+            }
         } else if (component.equals("DataExtraction")) {
             System.out.println("Starting Data Extraction");
             DataExtractor dataextractor = null;

--- a/code/componentsrunner/src/main/java/ca/sfu/cs/componentsrunner/app/RunComponent.java
+++ b/code/componentsrunner/src/main/java/ca/sfu/cs/componentsrunner/app/RunComponent.java
@@ -51,12 +51,12 @@ public class RunComponent {
             String falseTableSubQuery = Sort_merge3.sort_merge(
                 dbConnection,
                 config.getProperty("dbname"),
-                config.getProperty("SortMergeCartesianTable"),
+                config.getProperty("SortMergeCartesianTableSubQuery"),
                 config.getProperty("SortMergeSubsetTable")
             );
             try (Statement statement = dbConnection.createStatement()) {
                 statement.executeUpdate(
-                    "CREATE VIEW " + config.getProperty("SortMergeOutputTable") + " AS " +
+                    "CREATE TABLE " + config.getProperty("SortMergeOutputTable") + " AS " +
                     falseTableSubQuery
                 );
             }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -217,7 +217,7 @@ public class CountsManager {
                 rchainInfos = relationshipLattice.getRChainsInfo(len);
                 buildRChainsCT(rchainInfos, len, joinTableQueries, countingStrategy.getStorageEngine());
             }
-            RuntimeLogger.adjustLogEntryValue(dbConnection, "buildFlatStarCT", System.currentTimeMillis() - start);
+            RuntimeLogger.updateLogEntry(dbConnection, "buildFlatStarCT", System.currentTimeMillis() - start);
         }
 
         long l2 = System.currentTimeMillis();  //@zqian
@@ -254,10 +254,8 @@ public class CountsManager {
         );
         long rcountsRuntime = System.currentTimeMillis() - start;
 
-        // Add the runtime to the buildRChainCounts portion since that is where the runtime belongs to.
-        RuntimeLogger.adjustLogEntryValue(dbConnection, "buildRChainCounts", rcountsRuntime);
-        // Subtract this time from the buildFlatStarCT to make sure the times are correct.
-        RuntimeLogger.adjustLogEntryValue(dbConnection, "buildFlatStarCT", -1 * rcountsRuntime);
+        // Add runtime to a column used to add to the "Counts" portion and subtract from the "Moebius Join" portion.
+        RuntimeLogger.updateLogEntry(dbConnection, "buildRNodeCounts", rcountsRuntime);
 
         // Build the _star table.
         buildRNodeStar(rnode, shortRNode);

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/Sort_merge3.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/Sort_merge3.java
@@ -30,13 +30,13 @@ public class Sort_merge3 {
 
 
     /**
-     * Subtract the MULT column of the rows in {@code table1} by the MULT column of the matching row in
+     * Subtract the MULT column of the rows in {@code table1Subquery} by the MULT column of the matching row in
      * {@code table2}.
      *
      * @param conn - connection to the database containing {@code table1} and {@code table2}.
      * @param sourceDatabaseName - the name of the database containing {@code table1} and {@code table2}.
-     * @param table1 - the table to have its values in the MULT column subtracted by the MULT column in
-     *                 {@code table2}.
+     * @param table1Subquery - a subquery that generates a table to have its values in the MULT column subtracted by
+     *                         the MULT column in {@code table2}.
      * @param table2 - the table to match rows with in {@code table1} and subtract by the values found in the
      *                 MULT column.
      * @return an SQL query that applies the sort merge algorithm to the two specified tables.
@@ -45,40 +45,39 @@ public class Sort_merge3 {
     public static String sort_merge(
         Connection conn,
         String sourceDatabaseName,
-        String table1,
+        String table1Subquery,
         String table2
     ) throws SQLException {
         // Ensure that all the table names are escaped before attempting to execute any queries with them.
-        table1 = sourceDatabaseName + ".`" + table1 + "`";
         table2 = sourceDatabaseName + ".`" + table2 + "`";
 
         Statement st1 = conn.createStatement();
 
-        ArrayList<String> orderList = new ArrayList<String>();
+        ArrayList<String> joinOnList = new ArrayList<String>();
 
         /**
-         * Code for getting the ORDER BY sequence using TABLE1, IT DOES NOT MATTER WHICH TABLE WE USE AS BOTH TABLES HAVE SAME COLUMNS.
+         * Get the JOIN ON columns using TABLE2.
          */
         ResultSet rst = st1.executeQuery(
-            "SHOW COLUMNS FROM " + table1 +
+            "SHOW COLUMNS FROM " + table2 +
             "WHERE field <> \"MULT\";"
         );
 
         while(rst.next()) {
-            orderList.add(rst.getString(1));
+            joinOnList.add(rst.getString(1));
         }
         rst.close();
         st1.close();
 
         String selectQuery;
-        if (orderList.size() > 0) {
-            selectQuery = QueryGenerator.createSubtractionQuery(table1, table2, "MULT", orderList);
+        if (joinOnList.size() > 0) {
+            selectQuery = QueryGenerator.createSubtractionQuery(table1Subquery, table2, "MULT", joinOnList);
         } else {
             // Aug 18, 2014 zqian: Handle the extreme case when there's only the `MULT` column.
             logger.fine("\n\tHandle the extreme case when there's only the `MULT` column.\n");
             selectQuery =
-                "SELECT (" + table1 + ".MULT - " + table2 + ".MULT) AS MULT " +
-                "FROM " + table1 + ", " + table2;
+                "SELECT (SUBQUERY.MULT - " + table2 + ".MULT) AS MULT " +
+                "FROM (" + table1Subquery + ") AS SUBQUERY, " + table2;
         }
 
         logger.fine(selectQuery);

--- a/code/factorbase/src/main/resources/scripts/logging.sql
+++ b/code/factorbase/src/main/resources/scripts/logging.sql
@@ -5,6 +5,7 @@ CREATE TABLE CallLogs (
     populateMQ INT, -- MetaData
     populateMQRChain INT, -- MetaData
     buildPVarsCounts INT, -- Counts
+    buildRNodeCounts INT, -- Add to Counts, Subtract from Mobius Join
     buildRChainCounts INT, -- Counts
     createJoinTableQueries INT, -- Mobius Join
     buildFlatStarCT INT -- Mobius Join

--- a/code/factorbase/src/test/java/ca/sfu/cs/factorbase/util/Sort_merge3Test.java
+++ b/code/factorbase/src/test/java/ca/sfu/cs/factorbase/util/Sort_merge3Test.java
@@ -20,12 +20,19 @@ public class Sort_merge3Test {
         String SORT_MERGE_TABLE = "sort-merge-output";
         TestDatabaseConnection db = new TestDatabaseConnection();
 
-        Sort_merge3.sort_merge(
+        String falseTableSubQuery = Sort_merge3.sort_merge(
             db.con,
+            "`" + TestDatabaseConnection.DATABASE_NAME + "`",
             "sort-merge-t1",
-            "sort-merge-t2",
-            SORT_MERGE_TABLE
+            "sort-merge-t2"
         );
+
+        try (Statement statement = db.con.createStatement()) {
+            statement.executeUpdate(
+                "CREATE VIEW `" + SORT_MERGE_TABLE + "` AS " +
+                falseTableSubQuery
+            );
+        }
 
         Statement st = db.con.createStatement();
         ResultSet rs = st.executeQuery(

--- a/code/factorbase/src/test/java/ca/sfu/cs/factorbase/util/Sort_merge3Test.java
+++ b/code/factorbase/src/test/java/ca/sfu/cs/factorbase/util/Sort_merge3Test.java
@@ -23,13 +23,13 @@ public class Sort_merge3Test {
         String falseTableSubQuery = Sort_merge3.sort_merge(
             db.con,
             "`" + TestDatabaseConnection.DATABASE_NAME + "`",
-            "sort-merge-t1",
+            "SELECT * FROM `sort-merge-t1`",
             "sort-merge-t2"
         );
 
         try (Statement statement = db.con.createStatement()) {
             statement.executeUpdate(
-                "CREATE VIEW `" + SORT_MERGE_TABLE + "` AS " +
+                "CREATE TABLE `" + SORT_MERGE_TABLE + "` AS " +
                 falseTableSubQuery
             );
         }
@@ -86,7 +86,7 @@ public class Sort_merge3Test {
         // Clean up the output sort merge table.
         st.executeUpdate(
             MessageFormat.format(
-                "DROP VIEW {0}",
+                "DROP TABLE {0}",
                 "`" + SORT_MERGE_TABLE + "`"
             )
         );

--- a/code/factorbase/src/test/java/testframework/TestDatabaseConnection.java
+++ b/code/factorbase/src/test/java/testframework/TestDatabaseConnection.java
@@ -11,9 +11,10 @@ import ca.sfu.cs.factorbase.database.MySQLFactorBaseDataBase;
  * Class to connect to a MySQL database so that queries can be tested.
  */
 public class TestDatabaseConnection {
+    public static final String DATABASE_NAME = "tests-database";
     private static final String DEFAULT_USERNAME = "root";
     private static final String DEFAULT_PASSWORD = "";
-    private static final String MYSQL_URL = "jdbc:mysql://127.0.0.1/tests-database";
+    private static final String MYSQL_URL = "jdbc:mysql://127.0.0.1/" + DATABASE_NAME;
 
     public Connection con;
 


### PR DESCRIPTION
- Instead of materializing creating "_false" and "_star" tables, their information is captured using subqueries so that we can avoid materializing the tables.
- Added a new column (buildRNodeCounts) to the CallLogs table so that we can make one database call instead of two to help correct the runtime for the Moebius Join portion of the runtime.

Note: I am seeing if a similar change can be applied to the "_counts" tables for RNodes/RChains.

Update: It looks like applying a similar change to the "_counts" tables for RNodes also helps (for both small and large datasets) so I've included a commit for that change as well now.  I was looking at the runtimes I've collected so far, and I'm not too sure about this, but a recent change might have affected the runtime for building the global counts tables.  Just running some tests to confirm this, hopefully it's nothing though.