### PR TITLE
Disabled generation of global counts for the Ondemand strategy.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/app/RunBB.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/app/RunBB.java
@@ -81,7 +81,7 @@ public class RunBB {
             long buildCTStart = System.currentTimeMillis();
             CountsManager.buildCT(countingStrategy);
             RuntimeLogger.logRunTime(logger, "Creating CT Tables", buildCTStart, System.currentTimeMillis());
-        } else {
+        } else if (countingStrategy.isHybrid()) {
             long buildGlobalCountsStart = System.currentTimeMillis();
             CountsManager.buildRChainsGlobalCounts();
             RuntimeLogger.logRunTime(logger, "Creating Global Counts Tables", buildGlobalCountsStart, System.currentTimeMillis());


### PR DESCRIPTION
- The global counts is only for the Hybrid method so it has been
  disabled for the Ondemand strategy.