### PR TITLE
"_counts" and "_CT" Table Runtimes Written to the Console Output.

### DIFF
--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
@@ -367,7 +367,7 @@ public class BayesBaseH {
 
                 Statement st2 = con2.createStatement();
                 // Insert the BN nodes into Entity_BayesNet.
-                logger.fine(selectQuery);
+                RuntimeLogger.logExecutedQuery(logger, selectQuery);
                 ResultSet rs2 = st2.executeQuery(selectQuery);
                 String child = "";
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/BayesBaseH.java
@@ -209,8 +209,6 @@ public class BayesBaseH {
         CountingStrategy countingStrategy,
         RelationshipLattice lattice
     ) throws SQLException, IOException, DataBaseException, DataExtractionException, ParsingException, ScoringException {
-        long l = System.currentTimeMillis(); // @zqian: measure structure learning time.
-
         // Handle pvars.
         if (countingStrategy.isPrecount()) {
             learnStructurePVars(database); // import @zqian
@@ -243,9 +241,6 @@ public class BayesBaseH {
          * 3. Make sure you insert "<rnid> null" into PathBN as well.
          * zqian, when link is off, check the local_ct for rnode?
          */
-
-        long l2 = System.currentTimeMillis(); // @zqian: Measure structure learning time.
-        logger.fine("\n*****************\nStructure Learning Time(ms): " + (l2 - l) + " ms.\n");
     }
 
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -295,7 +295,7 @@ public class CountsManager {
         );
 
         dbConnection.setCatalog(targetDatabaseName);
-        logger.fine("\nCREATE CT table String: " + createCTQuery);
+        RuntimeLogger.logExecutedQuery(logger, createCTQuery);
         try (Statement statement = dbConnection.createStatement()) {
             statement.executeUpdate(createCTQuery);
         }
@@ -607,7 +607,7 @@ public class CountsManager {
                     storageEngine,
                     queryStringflat
                 );
-                logger.fine("\n create flat String : " + createStringflat );         
+                RuntimeLogger.logExecutedQuery(logger, createStringflat);
                 st3.execute(createStringflat);      //create flat table
 
                 // Add covering index.
@@ -840,8 +840,8 @@ public class CountsManager {
             storageEngine,
             queryString
         );
-        logger.fine("CREATE String: " + createString);
 
+        RuntimeLogger.logExecutedQuery(logger, createString);
         dbConnection.setCatalog(targetDatabaseName);
         try (Statement st2 = dbConnection.createStatement()) {
             st2.execute(createString);
@@ -944,11 +944,11 @@ public class CountsManager {
 
             if (copyToCT) {
                 dbConnection.setCatalog(dbTargetName);
+                String createString_CT =
+                    "CREATE TABLE `" + shortRchain + "_CT`" + " AS " +
+                        countsTableSubQuery;
+                RuntimeLogger.logExecutedQuery(logger, createString_CT);
                 try (Statement statement = dbConnection.createStatement()) {
-                    String createString_CT =
-                        "CREATE TABLE `" + shortRchain + "_CT`" + " AS " +
-                            countsTableSubQuery;
-                    logger.fine("CREATE String: " + createString_CT);
                     statement.execute(createString_CT);
                 }
             }
@@ -1257,7 +1257,7 @@ public class CountsManager {
             storageEngine,
             queryString
         );
-        logger.fine("\nCREATE String: " + createString);
+        RuntimeLogger.logExecutedQuery(logger, createString);
         dbConnection.setCatalog(databaseName_CT);
         try (Statement createStatement = dbConnection.createStatement()) {
             createStatement.executeUpdate(createString);

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -293,14 +293,12 @@ public class CountsManager {
             countingStrategy.getStorageEngine(),
             ctCreationQuery
         );
-        start = System.currentTimeMillis();
+
         dbConnection.setCatalog(targetDatabaseName);
         logger.fine("\nCREATE CT table String: " + createCTQuery);
         try (Statement statement = dbConnection.createStatement()) {
             statement.executeUpdate(createCTQuery);
         }
-
-        logger.fine("Build Time for RNode CT: " + (System.currentTimeMillis() - start) + "ms.\n");
     }
 
 
@@ -325,7 +323,6 @@ public class CountsManager {
     ) throws SQLException {
         String ctTablesCacheKey = ctTableName + ctCreationQuery;
         String cacheTableName = ctTablesCache.get(ctTablesCacheKey);
-        long start = System.currentTimeMillis();
         if (cacheTableName == null) {
             // Create the table in the CT cache database.
             cacheTableName = ctTableName + "_" + tableID;
@@ -350,8 +347,6 @@ public class CountsManager {
                 "FROM " + databaseName_CT_cache + "." + cacheTableName;
             createViewStatement.executeUpdate(viewQuery);
         }
-
-        logger.fine("Build Time for RNode CT: " + (System.currentTimeMillis() - start) + "ms.\n");
     }
 
 
@@ -493,8 +488,6 @@ public class CountsManager {
         Map<String, String> joinTableQueries,
         String storageEngine
     ) throws SQLException {
-        logger.fine("\n ****************** \n" +
-                "Building the _CT tables for Length = "+len +"\n" );
         int fc=0;
         for (FunctorNodesInfo rchainInfo : rchainInfos)
         {
@@ -584,7 +577,6 @@ public class CountsManager {
                         "SELECT " + MultString + " AS `MULT` " +
                         "FROM " + fromString;
                 }
-                logger.fine("Query String : " + queryString );   
 
                 dbConnection.setCatalog(databaseName_CT);
                 Statement st3 = dbConnection.createStatement();
@@ -592,9 +584,6 @@ public class CountsManager {
                 //make the rnid shorter 
                 String rnid_or=removedShort;
 
-                logger.fine(queryString);
-
-                long l3 = System.currentTimeMillis(); 
                 //staring to create the _flat table
                 // Oct 16 2013
                 // cur_CT_Table should be the one generated in the previous iteration
@@ -628,8 +617,6 @@ public class CountsManager {
                     cur_flat_Table
                 );
 
-                long l4 = System.currentTimeMillis(); 
-                logger.fine("Building Time(ms) for "+cur_flat_Table+ " : "+(l4-l3)+" ms.\n");
                 /**********starting to create _flase table***using sort_merge*******************************/
 
                 // Computing the false table as the MULT difference between the matching rows of the star and flat tables.
@@ -640,8 +627,6 @@ public class CountsManager {
                     queryString,
                     cur_flat_Table
                 );
-
-                long l5 = System.currentTimeMillis(); 
 
                 // staring to create the CT table
                 ResultSet rs_45 = st2.executeQuery(
@@ -694,13 +679,10 @@ public class CountsManager {
                 //  close statements
                 st2.close();            
                 st3.close();
-                long l6 = System.currentTimeMillis(); 
-                logger.fine("Building Time(ms) for "+cur_CT_Table+ " : "+(l6-l5)+" ms.\n");
             }
             st1.close();
             rs1.close();
         }
-        logger.fine("\n Build CT_RChain_TABLES for length = "+len+" are DONE \n" );
     }
 
 
@@ -711,7 +693,6 @@ public class CountsManager {
      * @throws SQLException if there are issues executing the SQL queries.
      */
     private static void buildPVarsCounts(CountingStrategy countingStrategy) throws SQLException {
-        long l = System.currentTimeMillis(); //@zqian : measure structure learning time
         dbConnection.setCatalog(databaseName_BN);
         Statement st = dbConnection.createStatement();
         ResultSet rs = st.executeQuery(
@@ -767,8 +748,6 @@ public class CountsManager {
 
         rs.close();
         st.close();
-        long l2 = System.currentTimeMillis(); //@zqian : measure structure learning time
-        logger.fine("Building Time(ms) for Pvariables counts: "+(l2-l)+" ms.\n");
     }
 
 
@@ -1196,7 +1175,6 @@ public class CountsManager {
         }
         queryString += " FROM " + fromString;
 
-        logger.fine(queryString);
         return queryString;
     }
 
@@ -1216,8 +1194,6 @@ public class CountsManager {
         String storageEngine,
         String countsTableSubQuery
     ) throws SQLException {
-        long start = System.currentTimeMillis(); // @zqian: measure structure learning time.
-
         dbConnection.setCatalog(databaseName_BN);
         Statement statement = dbConnection.createStatement();
 
@@ -1293,9 +1269,6 @@ public class CountsManager {
             databaseName_CT,
             flatTableName
         );
-
-        long end = System.currentTimeMillis(); // @zqian: measure structure learning time.
-        logger.fine("Build Time(ms) for RNode Flat: " + (end - start) + " ms.\n");
     }
 
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -199,8 +199,6 @@ public class CountsManager {
             for (FunctorNodesInfo rnodeInfo : rchainInfos) {
                 String rnode = rnodeInfo.getID();
                 String shortRNode = rnodeInfo.getShortID();
-                logger.fine("RNode: " + rnode);
-                logger.fine("Short RNode: " + shortRNode);
                 String ctTableName = shortRNode + "_CT";
                 String ctCreationQuery = buildRNodeCTCreationQuery(rnode, shortRNode, joinTableQueries);
 
@@ -491,13 +489,10 @@ public class CountsManager {
         {
             // Get the short and full form rnids for further use.
             String rchain = rchainInfo.getID();
-            logger.fine("\n RChain : " + rchain);
             String shortRchain = rchainInfo.getShortID();
-            logger.fine(" Short RChain : " + shortRchain);
             // Oct 16 2013
             // initialize the cur_CT_Table, at very beginning we will use _counts table to create the _flat table
             String cur_CT_Table = shortRchain + "_counts";
-            logger.fine(" cur_CT_Table : " + cur_CT_Table);
             // counts represents the ct tables where all relationships in Rchain are true
 
             //  create new statement
@@ -515,11 +510,8 @@ public class CountsManager {
             while(rs1.next())
             {       
                 String removed = rs1.getString("removed");
-                logger.fine("\n removed : " + removed);  
                 String removedShort = rs1.getString("short_rnid");
-                logger.fine("\n removed short : " + removedShort);
                 String BaseName = shortRchain + "_" + removedShort;
-                logger.fine(" BaseName : " + BaseName );
 
                 dbConnection.setCatalog(databaseName_BN);
                 Statement st2 = dbConnection.createStatement();
@@ -596,7 +588,6 @@ public class CountsManager {
                 // Oct 16 2013
                 // cur_CT_Table should be the one generated in the previous iteration
                 // for the very first iteration, it's _counts table
-                logger.fine("cur_CT_Table is : " + cur_CT_Table);
 
                 String cur_flat_Table = removedShort + len + "_" + fc + "_flat";
                 String queryStringflat = "SELECT SUM(`" + cur_CT_Table + "`.MULT) AS 'MULT' ";
@@ -735,7 +726,6 @@ public class CountsManager {
 
         while(rs.next()){
             String pvid = rs.getString("pvid");
-            logger.fine("pvid : " + pvid);
             String countsTableName = pvid + "_counts";
             String selectQuery = QueryGenerator.createMetaQueriesExtractionQuery(
                 pvid,
@@ -768,7 +758,6 @@ public class CountsManager {
         st.close();
         long l2 = System.currentTimeMillis(); //@zqian : measure structure learning time
         logger.fine("Building Time(ms) for Pvariables counts: "+(l2-l)+" ms.\n");
-        logger.fine("\n Pvariables are DONE \n" );
     }
 
 
@@ -947,9 +936,7 @@ public class CountsManager {
         for (FunctorNodesInfo rchainInfo : rchainInfos) {
             // Get the short and full form rnids for further use.
             String rchain = rchainInfo.getID();
-            logger.fine("\n RChain: " + rchain);
             String shortRchain = rchainInfo.getShortID();
-            logger.fine(" Short RChain: " + shortRchain);
 
             String countsTableSubQuery = generateCountsTableQuery(
                 dbTargetName,
@@ -976,8 +963,6 @@ public class CountsManager {
                 }
             }
         }
-
-        logger.fine("\n RChain_counts are DONE \n");
     }
 
 
@@ -1401,9 +1386,7 @@ public class CountsManager {
         while(rs.next()){
         //  get rnid
             String short_rnid = rs.getString("short_rnid");
-            logger.fine("\n short_rnid : " + short_rnid);
             String orig_rnid = rs.getString("orig_rnid");
-            logger.fine("\n orig_rnid : " + orig_rnid);
 
             Statement st2 = dbConnection.createStatement();
 
@@ -1431,7 +1414,6 @@ public class CountsManager {
 
         rs.close();
         st.close();
-        logger.fine("\n Rnodes_joins are DONE \n" );
 
         return joinTableQueries;
     }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/learning/CountsManager.java
@@ -536,7 +536,6 @@ public class CountsManager {
                 );
                 List<String> columns = extractEntries(rs2, "Entries");
                 String selectString = String.join(", ", columns);
-                logger.fine("Select String : " + selectString);
                 rs2.close();
                 //  create mult query string
                 ResultSet rs3 = st2.executeQuery(
@@ -550,11 +549,9 @@ public class CountsManager {
                 );
                 columns = extractEntries(rs3, "Entries");
                 String MultString = makeStarSepQuery(columns);
-                logger.fine("Mult String : " + MultString+ " as `MULT`");
                 rs3.close();
                 //  create from query string
                 String fromString = String.join(", ", columns);
-                logger.fine("From String : " + fromString);          
                 //  create where query string
                 ResultSet rs5 = st2.executeQuery(
                     QueryGenerator.createMetaQueriesExtractionQuery(
@@ -567,7 +564,6 @@ public class CountsManager {
                 );
                 columns = extractEntries(rs5, "Entries");
                 String whereString = String.join(" AND ", columns);
-               logger.fine("Where String : " + whereString);
                 rs5.close();
                 //  create the final query
                 String queryString ="";
@@ -654,7 +650,6 @@ public class CountsManager {
                 );
                 columns = extractEntries(rs_45, "Entries");
                 String CTJoinString = makeEscapedCommaSepQuery(columns);
-                logger.fine("CT Join String : " + CTJoinString);
 
                 //join false table with join table to add in rnid (= F) and 2nid (= n/a). then can union with CT table
                 String QueryStringCT =
@@ -797,7 +792,6 @@ public class CountsManager {
         dbConnection.setCatalog(databaseName_BN);
         Statement st = dbConnection.createStatement();
         String selectString = String.join(", ", columnAliases);
-        logger.fine("SELECT String: " + selectString);
 
         // Create FROM query.
         String fromQuery = QueryGenerator.createMetaQueriesExtractionQuery(
@@ -847,8 +841,6 @@ public class CountsManager {
         }
 
         st.close();
-
-        logger.fine("WHERE String:" + whereString);
 
         // Create the final query.
         String queryString =
@@ -1040,8 +1032,6 @@ public class CountsManager {
             selectString = String.join(", ", selectAliases);
         }
 
-        logger.fine("SELECT String: " + selectString);
-
         // Create FROM query string.
         String fromString = databaseName_global_counts + ".`" + countsTableName + "`";
 
@@ -1061,8 +1051,6 @@ public class CountsManager {
             List<String> fromAliases = extractEntries(rs3, "Entries");
             fromString = String.join(", ", fromAliases);
         }
-
-        logger.fine("FROM String: " + fromString);
 
         // Create WHERE query string.
         String whereString = null;

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/LoggerConfig.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/LoggerConfig.java
@@ -48,6 +48,7 @@ public class LoggerConfig {
     public static void buildLevelMap() {
         levelMap = new HashMap<String, Level>();
         levelMap.put("debug", Level.ALL);
+        levelMap.put("runtimeDetails", Level.FINE);
         levelMap.put("info", Level.INFO);
         levelMap.put("off", Level.OFF);
     }

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/RuntimeLogger.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/RuntimeLogger.java
@@ -52,6 +52,17 @@ public final class RuntimeLogger {
 
 
     /**
+     * Helper method to write out the SQL query that is being executed.
+     *
+     * @param logger - the logger to write the runtime to.
+     * @param query - the SQL query that is being executed.
+     */
+    public static void logExecutedQuery(Logger logger, String query) {
+        logger.finer("EXECUTING: " + query);
+    }
+
+
+    /**
      * Create the "CallLogs" table within the specified database.
      *
      * @param dbConnection - connection to the database server to create the "CallLogs" table in.

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/RuntimeLogger.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/RuntimeLogger.java
@@ -26,7 +26,8 @@ public final class RuntimeLogger {
 
 
     /**
-     * Helper method to write out the run times in a consistent format.
+     * Helper method to write out the run times for high level components in a consistent format.
+     *
      * @param logger - the logger to write the runtime to.
      * @param stage - the part of the FactorBase program that was run.
      * @param start - the start time for the given stage (ms).
@@ -34,6 +35,19 @@ public final class RuntimeLogger {
      */
     public static void logRunTime(Logger logger, String stage, long start, long end) {
         logger.info("Runtime[" + stage + "]: " + String.valueOf(end - start) + "ms.");
+    }
+
+
+    /**
+     * Helper method to write out the run times for components of high level components in a consistent format.
+     *
+     * @param logger - the logger to write the runtime to.
+     * @param subStage - the subcomponent of the part of the FactorBase program that was run.
+     * @param start - the start time for the given stage (ms).
+     * @param end - the end time for the given stage (ms).
+     */
+    public static void logRunTimeDetails(Logger logger, String stage, long start, long end) {
+        logger.fine("  Runtime[" + stage + "]: " + String.valueOf(end - start) + "ms.");
     }
 
 

--- a/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/Sort_merge3.java
+++ b/code/factorbase/src/main/java/ca/sfu/cs/factorbase/util/Sort_merge3.java
@@ -74,13 +74,11 @@ public class Sort_merge3 {
             selectQuery = QueryGenerator.createSubtractionQuery(table1Subquery, table2, "MULT", joinOnList);
         } else {
             // Aug 18, 2014 zqian: Handle the extreme case when there's only the `MULT` column.
-            logger.fine("\n\tHandle the extreme case when there's only the `MULT` column.\n");
             selectQuery =
                 "SELECT (SUBQUERY.MULT - " + table2 + ".MULT) AS MULT " +
                 "FROM (" + table1Subquery + ") AS SUBQUERY, " + table2;
         }
 
-        logger.fine(selectQuery);
         return selectQuery;
     }
 }

--- a/travis-resources/config.cfg
+++ b/travis-resources/config.cfg
@@ -20,4 +20,9 @@ SkipParameterLearning = 0
 # 2 - Hybrid
 CountingStrategy = 0
 
+# Logging levels for console output.
+# off - No console output.
+# info - Basic console output.
+# runtimeDetails - Additional runtime information.
+# debug - Detailed information.
 LoggingLevel = info


### PR DESCRIPTION
- Removed many unnecessary console output statements.
- Added a new logging level, runtimeDetails, to display additional
  runtimes (for counts and CT table creation) to the console.
- Cleaned up the console output so that most of the executed queries
  are only written to the console output when the logging level is set to "debug".
- Improved the logic for determining when/if the "_counts" tables for
  RChains should be created.
- When building the "_counts" tables for the global counts or precount
  we should start from an RChain length of 1 since we need to build
  all the tables.
- When building the "_counts" tables for ondemand or hybrid we should
  start from an RChain length of 2 since we cache the CT tables
  meaning that we might not need to construct the "_counts" table for
  some RNodes.  Also, for hybrid we use subqueries instead of
  materializing the tables for RNodes, so creating the tables is
  unnecessary for RNodes.