### PR TITLE
Revert SQL script table creation changes.

### DIFF
--- a/code/factorbase/src/main/resources/scripts/initialize_databases.sql
+++ b/code/factorbase/src/main/resources/scripts/initialize_databases.sql
@@ -1,7 +1,5 @@
 -- Initialize the databases required by FactorBase.
-
-/*M!100316 SET collation_server = 'latin1_swedish_ci';*/
-SET collation_database = 'latin1_swedish_ci';
+/*M!100316 SET collation_server = 'utf8_general_ci';*/
 
 DROP SCHEMA IF EXISTS @database@_setup;
 CREATE SCHEMA @database@_setup;
@@ -17,11 +15,3 @@ CREATE SCHEMA @database@_global_counts;
 
 DROP SCHEMA IF EXISTS @database@_CT_cache;
 CREATE SCHEMA @database@_CT_cache;
-
-ALTER DATABASE @database@_setup CHARACTER SET latin1 COLLATE  latin1_swedish_ci;
-ALTER DATABASE @database@_BN CHARACTER SET latin1 COLLATE  latin1_swedish_ci;
-ALTER DATABASE @database@_CT CHARACTER SET latin1 COLLATE  latin1_swedish_ci;
-ALTER DATABASE @database@_global_counts CHARACTER SET latin1 COLLATE  latin1_swedish_ci;
-ALTER DATABASE @database@_CT_cache CHARACTER SET latin1 COLLATE  latin1_swedish_ci;
-
-

--- a/code/factorbase/src/main/resources/scripts/latticegenerator_initialize.sql
+++ b/code/factorbase/src/main/resources/scripts/latticegenerator_initialize.sql
@@ -2,31 +2,29 @@
 SET storage_engine=INNODB;
 
 CREATE TABLE lattice_membership (
-    name VARCHAR(399),
-    member VARCHAR(399),
+    name VARCHAR(398),
+    member VARCHAR(398),
     PRIMARY KEY(name, member)
-)CHARACTER SET latin1 COLLATE latin1_swedish_ci;
+);
 
 
 CREATE TABLE lattice_rel (
-    parent VARCHAR(399),
-    child VARCHAR(399),
+    parent VARCHAR(398),
+    child VARCHAR(398),
     removed VARCHAR(199),
     PRIMARY KEY(parent, child)
-)CHARACTER SET latin1 COLLATE latin1_swedish_ci;
-
+);
 
 
 CREATE TABLE lattice_set (
-    name VARCHAR(399),
+    name VARCHAR(398),
     length INT(11),
     PRIMARY KEY(name, length)
-)CHARACTER SET latin1 COLLATE latin1_swedish_ci;
-
+);
 
 
 CREATE TABLE lattice_mapping (
-    orig_rnid VARCHAR(399),
-    short_rnid VARCHAR(399),
+    orig_rnid VARCHAR(398),
+    short_rnid VARCHAR(20),
     PRIMARY KEY(orig_rnid, short_rnid)
-)CHARACTER SET latin1 COLLATE latin1_swedish_ci;
+);

--- a/code/factorbase/src/main/resources/scripts/latticegenerator_initialize_local.sql
+++ b/code/factorbase/src/main/resources/scripts/latticegenerator_initialize_local.sql
@@ -2,28 +2,25 @@
 SET storage_engine=MEMORY;
 
 CREATE TABLE lattice_membership (
-    name VARCHAR(399),
-    member VARCHAR(399),
+    name VARCHAR(398),
+    member VARCHAR(398),
     PRIMARY KEY(name, member)
-)CHARACTER SET latin1 COLLATE latin1_swedish_ci;
-
+);
 
 
 CREATE TABLE lattice_rel (
-    parent VARCHAR(399),
-    child VARCHAR(399),
+    parent VARCHAR(398),
+    child VARCHAR(398),
     removed VARCHAR(199),
     PRIMARY KEY(parent, child)
-)CHARACTER SET latin1 COLLATE latin1_swedish_ci;
-
+);
 
 
 CREATE TABLE lattice_set (
-    name VARCHAR(399),
+    name VARCHAR(398),
     length INT(11),
     PRIMARY KEY(name, length)
-)CHARACTER SET latin1 COLLATE latin1_swedish_ci;
-
+);
 
 
 CREATE VIEW lattice_mapping AS

--- a/code/factorbase/src/main/resources/scripts/metaqueries_initialize.sql
+++ b/code/factorbase/src/main/resources/scripts/metaqueries_initialize.sql
@@ -1,6 +1,6 @@
 /* Create the table and view necessary for storing metaquery information. */
 
-SET storage_engine=INNODB;
+SET storage_engine=MEMORY;
 
 CREATE TABLE MetaQueries (
     Lattice_Point varchar(398), /* e.g. pvid, rchain, prof0, a */


### PR DESCRIPTION
- Reverting SQL script changes that seem to only be needed if a specific version of MariaDB/MySQL is not used.  The version that has been shown to work is: MariaDB 10.4.17
- Revert character set and collation changes.
- Revert storage type change.